### PR TITLE
Added Probe Height and laser/drill mode switch

### DIFF
--- a/src/frmmain.cpp
+++ b/src/frmmain.cpp
@@ -300,6 +300,7 @@ bool frmMain::isGCodeFile(QString fileName)
           || fileName.endsWith(".nc", Qt::CaseInsensitive)
           || fileName.endsWith(".ncc", Qt::CaseInsensitive)
           || fileName.endsWith(".ngc", Qt::CaseInsensitive)
+          || fileName.endsWith(".gcode", Qt::CaseInsensitive)
           || fileName.endsWith(".tap", Qt::CaseInsensitive);
 }
 
@@ -363,6 +364,7 @@ void frmMain::loadSettings()
     m_settings->setLaserPowerMax(set.value("laserPowerMax", 100).toInt());
     m_settings->setRapidSpeed(set.value("rapidSpeed", 0).toInt());
     m_settings->setHeightmapProbingFeed(set.value("heightmapProbingFeed", 0).toInt());
+    m_settings->setHeightmapProbeHeight(set.value("heightmapProbeHeight", 0).toDouble());
     m_settings->setAcceleration(set.value("acceleration", 10).toInt());
     m_settings->setToolAngle(set.value("toolAngle", 0).toDouble());
     m_settings->setToolType(set.value("toolType", 0).toInt());
@@ -516,6 +518,7 @@ void frmMain::saveSettings()
     set.setValue("restoreMode", m_settings->restoreMode());
     set.setValue("rapidSpeed", m_settings->rapidSpeed());
     set.setValue("heightmapProbingFeed", m_settings->heightmapProbingFeed());
+    set.setValue("heightmapProbeHeight", m_settings->heightmapProbeHeight());
     set.setValue("acceleration", m_settings->acceleration());
     set.setValue("toolAngle", m_settings->toolAngle());
     set.setValue("toolType", m_settings->toolType());
@@ -1173,6 +1176,7 @@ void frmMain::onSerialPortReadyRead()
                         // "[PRB:0.000,0.000,0.000:0];ok"
                         QRegExp rx(".*PRB:([^,]*),([^,]*),([^]^:]*)");
                         double z = qQNaN();
+
                         if (rx.indexIn(response) != -1) {
                             qDebug() << "probing coordinates:" << rx.cap(1) << rx.cap(2) << rx.cap(3);
                             z = toMetric(rx.cap(3).toDouble());
@@ -1609,7 +1613,7 @@ void frmMain::on_cmdFileOpen_clicked()
         if (!saveChanges(false)) return;
 
         QString fileName  = QFileDialog::getOpenFileName(this, tr("Open"), m_lastFolder,
-                                   tr("G-Code files (*.nc *.ncc *.ngc *.tap *.txt);;All files (*.*)"));
+                                   tr("G-Code files (*.nc *.ncc *.ngc *.gcode *.tap *.txt);;All files (*.*)"));
 
         if (!fileName.isEmpty()) m_lastFolder = fileName.left(fileName.lastIndexOf(QRegExp("[/\\\\]+")));
 
@@ -2618,7 +2622,7 @@ bool frmMain::saveProgramToFile(QString fileName, GCodeTableModel *model)
 
 void frmMain::on_actFileSaveTransformedAs_triggered()
 {
-    QString fileName = (QFileDialog::getSaveFileName(this, tr("Save file as"), m_lastFolder, tr("G-Code files (*.nc *.ncc *.ngc *.tap *.txt)")));
+    QString fileName = (QFileDialog::getSaveFileName(this, tr("Save file as"), m_lastFolder, tr("G-Code files (*.nc *.ncc *.ngc *.gcode *.tap *.txt)")));
 
     if (!fileName.isEmpty()) {
         saveProgramToFile(fileName, &m_programHeightmapModel);
@@ -2628,7 +2632,7 @@ void frmMain::on_actFileSaveTransformedAs_triggered()
 void frmMain::on_actFileSaveAs_triggered()
 {
     if (!m_heightMapMode) {
-        QString fileName = (QFileDialog::getSaveFileName(this, tr("Save file as"), m_lastFolder, tr("G-Code files (*.nc *.ncc *.ngc *.tap *.txt)")));
+        QString fileName = (QFileDialog::getSaveFileName(this, tr("Save file as"), m_lastFolder, tr("G-Code files (*.nc *.ncc *.ngc *.gcode *.tap *.txt)")));
 
         if (!fileName.isEmpty()) if (saveProgramToFile(fileName, &m_programModel)) {
             m_programFileName = fileName;
@@ -3151,6 +3155,7 @@ bool frmMain::updateHeightMapGrid()
     // Generate probe program
     double gridStepX = gridPointsX > 1 ? borderRect.width() / (gridPointsX - 1) : 0;
     double gridStepY = gridPointsY > 1 ? borderRect.height() / (gridPointsY - 1) : 0;
+    double zoffset = m_settings->heightmapProbeHeight();
 
     qDebug() << "generating probe program";
 
@@ -3164,6 +3169,8 @@ bool frmMain::updateHeightMapGrid()
 //                         .arg(ui->txtHeightMapGridZTop->value()));
     m_probeModel.setData(m_probeModel.index(m_probeModel.rowCount() - 1, 1), QString("G38.2Z%1")
                          .arg(ui->txtHeightMapGridZBottom->value()));
+    m_probeModel.setData(m_probeModel.index(m_probeModel.rowCount() - 1, 1), QString("G92Z%1") // Set Z to Probe Height
+                         .arg(zoffset));
     m_probeModel.setData(m_probeModel.index(m_probeModel.rowCount() - 1, 1), QString("G0Z%1")
                          .arg(ui->txtHeightMapGridZTop->value()));
 
@@ -3181,6 +3188,8 @@ bool frmMain::updateHeightMapGrid()
                                  .arg(ui->txtHeightMapGridZTop->value()));
         }
     }
+
+    m_probeModel.setData(m_probeModel.index(m_probeModel.rowCount() - 1, 1), QString("G0X0Y0")); // Return to Point of Origin
 
     m_programLoading = false;
 

--- a/src/frmmain.h
+++ b/src/frmmain.h
@@ -193,6 +193,10 @@ private slots:
 
     void on_cmdStop_clicked();
 
+    void on_chkLaserMode_clicked();
+
+    void on_chkLaserMode_toggled(bool checked);
+
 protected:
     void showEvent(QShowEvent *se);
     void hideEvent(QHideEvent *he);

--- a/src/frmmain.ui
+++ b/src/frmmain.ui
@@ -664,7 +664,7 @@ QSlider::handle:horizontal:hover {
                  <double>999.000000000000000</double>
                 </property>
                 <property name="value">
-                 <double>1.000000000000000</double>
+                 <double>5.000000000000000</double>
                 </property>
                </widget>
               </item>
@@ -692,7 +692,7 @@ QSlider::handle:horizontal:hover {
                  <double>999.000000000000000</double>
                 </property>
                 <property name="value">
-                 <double>-1.000000000000000</double>
+                 <double>-10.000000000000000</double>
                 </property>
                </widget>
               </item>
@@ -822,10 +822,10 @@ QSlider::handle:horizontal:hover {
                  <enum>QAbstractSpinBox::NoButtons</enum>
                 </property>
                 <property name="decimals">
-                 <number>0</number>
+                 <number>2</number>
                 </property>
                 <property name="minimum">
-                 <double>2.000000000000000</double>
+                 <double>0.100000000000000</double>
                 </property>
                 <property name="maximum">
                  <double>1000.000000000000000</double>
@@ -853,10 +853,10 @@ QSlider::handle:horizontal:hover {
                  <enum>QAbstractSpinBox::NoButtons</enum>
                 </property>
                 <property name="decimals">
-                 <number>0</number>
+                 <number>2</number>
                 </property>
                 <property name="minimum">
-                 <double>2.000000000000000</double>
+                 <double>0.100000000000000</double>
                 </property>
                 <property name="maximum">
                  <double>1000.000000000000000</double>
@@ -1540,9 +1540,9 @@ QSlider::handle:horizontal:hover {
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>-416</y>
+            <y>0</y>
             <width>228</width>
-            <height>691</height>
+            <height>658</height>
            </rect>
           </property>
           <property name="sizePolicy">
@@ -2616,7 +2616,7 @@ padding-right: 8;</string>
      <x>0</x>
      <y>0</y>
      <width>952</width>
-     <height>26</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="mnuFile">

--- a/src/frmmain.ui
+++ b/src/frmmain.ui
@@ -822,10 +822,10 @@ QSlider::handle:horizontal:hover {
                  <enum>QAbstractSpinBox::NoButtons</enum>
                 </property>
                 <property name="decimals">
-                 <number>2</number>
+                 <number>0</number>
                 </property>
                 <property name="minimum">
-                 <double>0.100000000000000</double>
+                 <double>2.000000000000000</double>
                 </property>
                 <property name="maximum">
                  <double>1000.000000000000000</double>
@@ -853,10 +853,10 @@ QSlider::handle:horizontal:hover {
                  <enum>QAbstractSpinBox::NoButtons</enum>
                 </property>
                 <property name="decimals">
-                 <number>2</number>
+                 <number>0</number>
                 </property>
                 <property name="minimum">
-                 <double>0.100000000000000</double>
+                 <double>2.000000000000000</double>
                 </property>
                 <property name="maximum">
                  <double>1000.000000000000000</double>

--- a/src/frmmain.ui
+++ b/src/frmmain.ui
@@ -967,6 +967,31 @@ QSlider::handle:horizontal:hover {
           </widget>
          </item>
          <item>
+          <widget class="QCheckBox" name="chkUseProbeHeight">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>22</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Use Probe Height</string>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="spacerBot">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
@@ -1540,9 +1565,9 @@ QSlider::handle:horizontal:hover {
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>0</y>
+            <y>-416</y>
             <width>228</width>
-            <height>658</height>
+            <height>685</height>
            </rect>
           </property>
           <property name="sizePolicy">
@@ -2463,8 +2488,30 @@ QSlider::handle:horizontal:hover {
                  </item>
                  <item>
                   <widget class="QCheckBox" name="chkKeyboardControl">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
                    <property name="text">
                     <string>Keyboard control</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QCheckBox" name="chkLaserMode">
+                   <property name="enabled">
+                    <bool>true</bool>
+                   </property>
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string>Laser Mode</string>
                    </property>
                   </widget>
                  </item>

--- a/src/frmsettings.cpp
+++ b/src/frmsettings.cpp
@@ -330,6 +330,17 @@ void frmSettings::setHeightmapProbingFeed(int heightmapProbingFeed)
     ui->txtHeightMapProbingFeed->setValue(heightmapProbingFeed);
 }
 
+double frmSettings::heightmapProbeHeight()
+{
+    return ui->txtHeightMapProbeHeight->value();
+}
+
+void frmSettings::setHeightmapProbeHeight(double heightmapProbeHeight)
+{
+    ui->txtHeightMapProbeHeight->setValue(heightmapProbeHeight);
+}
+
+
 int frmSettings::acceleration()
 {
     return ui->txtAcceleration->value();
@@ -638,11 +649,12 @@ void frmSettings::on_cmdDefaults_clicked()
     setSpindleSpeedMax(10000);
     setLaserPowerMin(0);
     setLaserPowerMax(100);
-    setTouchCommand("G21G91G38.2Z-30F100; G0Z1; G38.2Z-2F10");
+    setTouchCommand("G21G91G38.2Z-30F100; G0Z1; G38.2Z-2F1; G92Z0(change Z0 by your probe Height and delete this text); G1Z5F200");
     setSafePositionCommand("G21G90; G53G0Z0");
     setMoveOnRestore(false);
     setRestoreMode(0);
     setHeightmapProbingFeed(10);
+    setHeightmapProbeHeight(1.55);
     setUnits(0);
 
     setArcLength(0.0);

--- a/src/frmsettings.h
+++ b/src/frmsettings.h
@@ -67,6 +67,8 @@ public:
     void setRapidSpeed(int rapidSpeed);
     int heightmapProbingFeed();
     void setHeightmapProbingFeed(int heightmapProbingFeed);
+    double heightmapProbeHeight();
+    void setHeightmapProbeHeight(double heightmapProbeHeight);
     int acceleration();
     void setAcceleration(int acceleration);
     int queryStateTime();
@@ -141,6 +143,8 @@ private slots:
     void on_radGrayscaleS_toggled(bool checked);
 
     void on_radGrayscaleZ_toggled(bool checked);
+
+    void on_chkGrayscale_clicked();
 
 private:
     Ui::frmSettings *ui;

--- a/src/frmsettings.ui
+++ b/src/frmsettings.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>555</width>
-    <height>715</height>
+    <width>557</width>
+    <height>755</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -71,9 +71,9 @@ QGroupBox {
         <property name="geometry">
          <rect>
           <x>0</x>
-          <y>0</y>
-          <width>436</width>
-          <height>1749</height>
+          <y>-376</y>
+          <width>391</width>
+          <height>1529</height>
          </rect>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -640,48 +640,69 @@ QGroupBox {
            <property name="title">
             <string>Heightmap</string>
            </property>
-           <layout class="QVBoxLayout" name="verticalLayout_11">
-            <item>
-             <layout class="QGridLayout" name="gridLayout_9" columnstretch="0,1,1">
-              <item row="3" column="0">
-               <widget class="QLabel" name="label_38">
-                <property name="text">
-                 <string>Heightmap probing feed:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <spacer name="horizontalSpacer_8">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="3" column="2">
-               <widget class="QSpinBox" name="txtHeightMapProbingFeed">
-                <property name="font">
-                 <font>
-                  <pointsize>9</pointsize>
-                 </font>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::NoButtons</enum>
-                </property>
-                <property name="maximum">
-                 <number>99999</number>
-                </property>
-               </widget>
-              </item>
-             </layout>
+           <layout class="QGridLayout" name="gridLayout_8">
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_38">
+              <property name="text">
+               <string>Heightmap probing feed:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QSpinBox" name="txtHeightMapProbingFeed">
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+               </font>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+              <property name="buttonSymbols">
+               <enum>QAbstractSpinBox::NoButtons</enum>
+              </property>
+              <property name="maximum">
+               <number>99999</number>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <spacer name="horizontalSpacer_17">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>28</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="0" column="3">
+             <widget class="QLabel" name="label_40">
+              <property name="text">
+               <string>Probe Height:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="4">
+             <widget class="QDoubleSpinBox" name="txtHeightMapProbeHeight">
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+               </font>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+              <property name="buttonSymbols">
+               <enum>QAbstractSpinBox::NoButtons</enum>
+              </property>
+             </widget>
             </item>
            </layout>
           </widget>


### PR DESCRIPTION
I have added two new checkbox:

Use probe Height: You can choose between use or not the probe height stored in the settings. So you can use it for materials as wood, etc or not use it when you are using a pcb.

Use laser mode: Is a simply send command to choose between laser or mill mode.

Thanks.