### PR TITLE
Added GRBL v1.1f status message support

### DIFF
--- a/src/candle.pro
+++ b/src/candle.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       = core gui opengl widgets serialport
+QT       = core gui opengl serialport
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
 win32: {

--- a/src/candle.pro
+++ b/src/candle.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       = core gui opengl serialport
+QT       = core gui opengl widgets serialport
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
 win32: {

--- a/src/frmmain.h
+++ b/src/frmmain.h
@@ -250,6 +250,11 @@ private:
 
     QMessageBox* m_senderErrorBox;
 
+    // Work coordinate offset from GRBL
+    double m_wcoX = 0;
+    double m_wcoY = 0;
+    double m_wcoZ = 0;
+
     // Stored origin
     double m_storedX = 0;
     double m_storedY = 0;

--- a/src/frmmain.ui
+++ b/src/frmmain.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>878</width>
+    <width>997</width>
     <height>899</height>
    </rect>
   </property>
@@ -1203,6 +1203,67 @@ QSlider::handle:horizontal:hover {
             </layout>
            </item>
            <item>
+            <widget class="QFrame" name="horizontalFrame">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>25</height>
+              </size>
+             </property>
+             <layout class="QHBoxLayout" name="horizontalLayout_33">
+              <property name="spacing">
+               <number>6</number>
+              </property>
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="QLabel" name="label_20">
+                <property name="text">
+                 <string>Feed</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLineEdit" name="txtFeedInfo">
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="readOnly">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_21">
+                <property name="text">
+                 <string>Speed</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLineEdit" name="txtSpeedInfo">
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="readOnly">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
             <layout class="QFormLayout" name="formLayout">
              <property name="horizontalSpacing">
               <number>14</number>
@@ -1535,8 +1596,8 @@ QSlider::handle:horizontal:hover {
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>231</width>
-            <height>725</height>
+            <width>252</width>
+            <height>795</height>
            </rect>
           </property>
           <property name="sizePolicy">
@@ -2792,8 +2853,8 @@ padding-right: 8;</string>
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>878</width>
-     <height>26</height>
+     <width>997</width>
+     <height>24</height>
     </rect>
    </property>
    <widget class="QMenu" name="mnuFile">


### PR DESCRIPTION
GRBL since version 1 was much reworked. Now status message queried by ? command has value groups separated by | character instead of comma. New status format contains only either WPos or MPos, not two ones together. To calculate MPos using WPos or vice versa there is WCO used. WCO is returned in status message, but not always, so we needed to store it when it's received from controller.
New statuses also added: 'Jog' and 'Sleep'.
I think this patch has back compatibility with v0.9 but not fully tested.

I also had some problems after aborting a gcode execution in version 1.1f. The Arduino halts after I press 'Abort' and does not respond on console commands.