### PR TITLE
Use OpenGL commands only in paintGL()

### DIFF
--- a/src/widgets/glwidget.cpp
+++ b/src/widgets/glwidget.cpp
@@ -412,12 +412,7 @@ void GLWidget::updateView()
     m_viewMatrix.rotate(-90, 1.0, 0.0, 0.0);
 }
 
-#ifdef GLES
 void GLWidget::paintGL() {
-#else
-void GLWidget::paintEvent(QPaintEvent *pe) {
-    Q_UNUSED(pe)
-#endif
     QPainter painter(this);
 
     // Segment counter

--- a/src/widgets/glwidget.h
+++ b/src/widgets/glwidget.h
@@ -138,11 +138,7 @@ protected:
     void resizeGL(int width, int height);
     void updateProjection();
     void updateView();
-#ifdef GLES
     void paintGL();
-#else
-    void paintEvent(QPaintEvent *pe);
-#endif
 
     void mousePressEvent(QMouseEvent *event);
     void mouseMoveEvent(QMouseEvent *event);


### PR DESCRIPTION
I compiled Candle from source on MacOS High Sierra and experienced a lot of crashes when launching the application. Upon debugging the issue I found that an assert inside glClearColor() within paintevent() triggered. The assert was checking whether OpenGL had been initialized. Indeed, initializeGL() was NOT called before the paintEvent appeared.

I read the documentation on QtOpenGL and the way I understand it is, that OpenGL commands have to be put inside paintGL(), which is called by the paintEvent() handler of the base class, which also takes care of properly calling initializeGL().

So I removed paintEvent() and renamed it in non-GLES code to paintGL(). That fixed the issue. OpenGL is now properly initialized and drawing works. (Sometimes Candle was able to launch without that change, but things were not drawn correctly. Maybe this fixes also some of the other reported drawing-related bugs.)

I don't really understand why there are OpenGL calls being issued in paintEvent(), but I believe this is wrong.

I'm also not sure why GLWidget inherits from QOpenGLWidget with GLES and from QGLWidget otherwise. My understanding is that QGLWidget is for backwards-compatibility with older Qt-Versions and QOpenGLWidget is its modern substitute. So I think QOpenGLWidget can always be used.

I'm new to the Candle code base and I'm happy to discuss this issue and make further fixes, if necessary.