### PR TITLE
added #include <QtWidgets>

### DIFF
--- a/src/candle/frmmain.cpp
+++ b/src/candle/frmmain.cpp
@@ -29,6 +29,7 @@
 #include <QAction>
 #include <QLayout>
 #include <QMimeData>
+#include <QtWidgets>
 #include "frmmain.h"
 #include "ui_frmmain.h"
 #include "ui_frmsettings.h"


### PR DESCRIPTION
before adding this line, compiler on linux reported:
error: invalid use of incomplete type ‘class QDrag’
error: invalid use of incomplete type ‘class QTranslator’
etc.