### PR TITLE
Added missing header includes for QDrag and QTranslator

### DIFF
--- a/src/candle/frmmain.cpp
+++ b/src/candle/frmmain.cpp
@@ -29,6 +29,8 @@
 #include <QAction>
 #include <QLayout>
 #include <QMimeData>
+#include <QDrag>
+#include <QTranslator>
 #include "frmmain.h"
 #include "ui_frmmain.h"
 #include "ui_frmsettings.h"


### PR DESCRIPTION
I had trouble compiling and it seems that these two header includes were just missing.