### PR TITLE
add #include lines needed to compile (at least on Ubuntu 20.04)

### DIFF
--- a/src/candle/frmmain.cpp
+++ b/src/candle/frmmain.cpp
@@ -29,6 +29,8 @@
 #include <QAction>
 #include <QLayout>
 #include <QMimeData>
+#include <QDrag>
+#include <QTranslator>
 #include "frmmain.h"
 #include "ui_frmmain.h"
 #include "ui_frmsettings.h"


### PR DESCRIPTION
Experimental Branch would not compile on Ubuntu 20.04 without #include <QTranslator> and #include <QDrag>.

