### PR TITLE
Add flatpak build manifest

### DIFF
--- a/src/com.github.Denvi.Candle.yaml
+++ b/src/com.github.Denvi.Candle.yaml
@@ -1,0 +1,21 @@
+app-id: com.github.Denvi.Candle
+runtime: org.kde.Platform
+runtime-version: '5.14'
+sdk: org.kde.Sdk
+command: Candle
+finish-args:
+    - --share=ipc
+    - --socket=x11
+    - --socket=wayland
+    - --filesystem=host
+    - --device=all
+modules:
+  - name: candle
+    buildsystem: simple
+    build-commands:
+        - cmake .
+        - make
+        - install -D Candle /app/bin/Candle
+    sources:
+        - type: dir
+          path: .


### PR DESCRIPTION
SImple manifest for [Flatpak](https://flatpak.org/).
Notes:
 * Tested on `org.Kde.Platform 5.14`
 * Uses --device=all, due lack of serial/device portal in flatpak
 * No desktop files

Prepare
 * install flatpak-builder
 * download sdk (flatpak install org.Kde.Platform//5.14 org.Kde.Sdk//5.14) 

Build
  
    flatpak-builder build-dir src/com.github.Denvi.Candle.yaml

Test

    flatpak-builder --run build-dir src/com.github.Denvi.Candle.yaml Candle