### PR TITLE
Fix jog in imperial units

### DIFF
--- a/src/candle/frmmain.cpp
+++ b/src/candle/frmmain.cpp
@@ -3952,13 +3952,13 @@ void frmMain::jogStep()
     if (m_jogVector.length() == 0) return;
 
     if (ui->cboJogStep->currentText().toDouble() == 0) {
-        const double acc = m_settings->acceleration();              // Acceleration mm/sec^2
-        int speed = ui->cboJogFeed->currentText().toInt();          // Speed mm/min
-        double v = (double)speed / 60;                              // Rapid speed mm/sec
-        int N = 15;                                                 // Planner blocks
-        double tt = 0.002;                                          // Transfer time
-        double dt = qMax(0.01, sqrt(v) / (2 * acc * (N - 1))) + tt; // Single jog command time
-        double s = v * dt;                                          // Jog distance
+        const double acc = m_settings->acceleration();                  // Acceleration mm/sec^2
+        int speed = toMetric(ui->cboJogFeed->currentText().toInt());    // Speed mm/min
+        double v = (double)speed / 60;                                  // Rapid speed mm/sec
+        int N = 15;                                                     // Planner blocks
+        double tt = 0.002;                                              // Transfer time
+        double dt = qMax(0.01, sqrt(v) / (2 * acc * (N - 1))) + tt;     // Single jog command time
+        double s = v * dt;                                              // Jog distance
 
         QVector3D vec = m_jogVector.normalized() * s;
 
@@ -3968,8 +3968,8 @@ void frmMain::jogStep()
                     .arg(vec.z(), 0, 'g', 4)
                     .arg(speed), -2, m_settings->showUICommands());
     } else {
-        int speed = ui->cboJogFeed->currentText().toInt();          // Speed mm/min
-        QVector3D vec = m_jogVector * ui->cboJogStep->currentText().toDouble();
+        int speed = toMetric(ui->cboJogFeed->currentText().toInt());    // Speed mm/min
+        QVector3D vec = m_jogVector * toMetric(ui->cboJogStep->currentText().toDouble());
 
         sendCommand(QString("$J=G21G91X%1Y%2Z%3F%4")
                     .arg(vec.x(), 0, 'g', 4)

--- a/src/candle/frmmain.cpp
+++ b/src/candle/frmmain.cpp
@@ -1307,7 +1307,7 @@ void frmMain::onSerialPortReadyRead()
                         // Spindle speed
                         QRegExp rx(".*S([\\d\\.]+)");
                         if (rx.indexIn(response) != -1) {
-                            double speed = toMetric(rx.cap(1).toDouble()); //RPM in imperial?
+                            double speed = rx.cap(1).toDouble();
                             ui->slbSpindle->setCurrentValue(speed);
                         }
 

--- a/src/candle/frmmain.cpp
+++ b/src/candle/frmmain.cpp
@@ -35,6 +35,9 @@
 #include "widgets/widgetmimedata.h"
 #include "widgets/uiloader.h"
 
+#include <QDrag>
+#include <QTranslator>
+
 frmMain::frmMain(QWidget *parent) :
     QMainWindow(parent),
     ui(new Ui::frmMain)


### PR DESCRIPTION
When set to inches ([`$13=1`](https://github.com/gnea/grbl/wiki/Grbl-v1.1-Configuration#13---report-inches-boolean)), the jog feature was still using millimetres and mm/min as the units for the jog step and feed rate. This changes them to be in inches and in/min, respectively.

One issue I noticed is that if `$13` is changed while Candle is running, Candle is still using the previous value (metric when switching to imperial and vice versa) until you restart it. This is not a problem with the code I added, Candle just reads the Grbl settings once (actually, it seems like it reads the settings each time a soft reset command `^X` is issued).
https://github.com/Denvi/Candle/blob/72a573380dd79db07c2f9a33ca3e028268f8e4f0/src/candle/frmmain.cpp#L1348-L1354
I don't think this is a big issue, though.

Tested on a Chinese 1610 CNC machine with Grbl 1.1h.
Ubuntu 18.04 64bit GNU/Linux operating system on the computer I use with the CNC machine, it also compiles just fine on my main Ubuntu 20.04 PC.

I wasn't able to compile the software without adding a few `#include` lines to `frmmain.cpp`, hence the first commit.

This fixes #456 