### PR TITLE
Fixed import capitalization

### DIFF
--- a/src/candle/scriptfunctions.cpp
+++ b/src/candle/scriptfunctions.cpp
@@ -1,5 +1,5 @@
 #include "scriptfunctions.h"
-#include "frmMain.h"
+#include "frmmain.h"
 
 ScriptFunctions::ScriptFunctions(QObject *parent): QObject(parent), m_frmMain(0)
 {


### PR DESCRIPTION
When building on Linux, the file can not be found with the capital letter