### PR TITLE
3 fixes of warnings and potential runtime errors

### DIFF
--- a/src/drawers/gcodedrawer.cpp
+++ b/src/drawers/gcodedrawer.cpp
@@ -39,6 +39,9 @@ bool GcodeDrawer::updateData()
     case GcodeDrawer::Raster:
         if (m_indexes.isEmpty()) return prepareRaster(); else return updateRaster();
     }
+    
+    // Nothing to update; success
+    return true;
 }
 
 bool GcodeDrawer::prepareVectors()

--- a/src/drawers/shaderdrawable.h
+++ b/src/drawers/shaderdrawable.h
@@ -9,7 +9,9 @@
 #include <QOpenGLTexture>
 #include "utils/util.h"
 
+#ifndef sNan
 #define sNan 65536.0
+#endif // sNan
 
 struct VertexData
 {

--- a/src/frmmain.cpp
+++ b/src/frmmain.cpp
@@ -3721,7 +3721,7 @@ void frmMain::on_chkHeightMapUse_clicked(bool checked)
         // Select first row
         ui->tblProgram->selectRow(0);
     }
-    catch (CancelException) {                       // Cancel modification
+    catch (CancelException const&) {                       // Cancel modification
         m_programHeightmapModel.clear();
         m_currentModel = &m_programModel;
 


### PR DESCRIPTION
Redefinition protection added
Added return statement to remove warning about control paths not returning value
Polymorphic exception should be caught by const ref