### PR TITLE
Add optional tcp support for connecting to grbl (plus other small improvements)

### DIFF
--- a/src/candle.vcxproj
+++ b/src/candle.vcxproj
@@ -13,13 +13,15 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{225C620D-C774-30C0-A16D-B392DA51D110}</ProjectGuid>
     <RootNamespace>Candle</RootNamespace>
-    <Keyword>Qt4VSv1.0</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <Keyword>QtVS_v303</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
+    <QTDIR>C:\Qt\5.12.10\msvc2017</QTDIR>
+    <QtMsBuild Condition="'$(QtMsBuild)'=='' or !Exists('$(QtMsBuild)\qt.targets')">$(MSBuildProjectDirectory)\QtMsBuild</QtMsBuild>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <OutputDirectory>release\</OutputDirectory>
     <ATLMinimizesCRunTimeLibraryUsage>false</ATLMinimizesCRunTimeLibraryUsage>
     <CharacterSet>NotSet</CharacterSet>
@@ -28,7 +30,7 @@
     <PrimaryOutput>Candle</PrimaryOutput>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <OutputDirectory>debug\</OutputDirectory>
     <ATLMinimizesCRunTimeLibraryUsage>false</ATLMinimizesCRunTimeLibraryUsage>
     <CharacterSet>NotSet</CharacterSet>
@@ -37,15 +39,9 @@
     <PrimaryOutput>Candle</PrimaryOutput>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <PropertyGroup Condition="'$(QtMsBuild)'=='' or !Exists('$(QtMsBuild)\qt.targets')">
-    <QtMsBuild>$(MSBuildProjectDirectory)\QtMsBuild</QtMsBuild>
-  </PropertyGroup>
   <Target Name="QtMsBuildNotFound" BeforeTargets="CustomBuild;ClCompile" Condition="!Exists('$(QtMsBuild)\qt.targets') or !Exists('$(QtMsBuild)\qt.props')">
     <Message Importance="High" Text="QtMsBuild: could not locate qt.targets, qt.props; project may not build correctly." />
   </Target>
-  <ImportGroup Condition="Exists('$(QtMsBuild)\qt.props')">
-    <Import Project="$(QtMsBuild)\qt.props" />
-  </ImportGroup>
   <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
@@ -54,20 +50,36 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">.\build-$(Platform)\$(Configuration)\Bin</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">.\build-$(Platform)\$(Configuration)\</IntDir>
-    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Candle</TargetName>
-    <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</IgnoreImportLibrary>
-    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.\build-$(Platform)\$(Configuration)\Bin</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.\build-$(Platform)\$(Configuration)\</IntDir>
-    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Candle</TargetName>
-    <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</IgnoreImportLibrary>
+  <ImportGroup Condition="Exists('$(QtMsBuild)\qt_defaults.props')">
+    <Import Project="$(QtMsBuild)\qt_defaults.props" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>.\build-$(Platform)\$(Configuration)\Bin\</OutDir>
+    <IntDir>.\build-$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>Candle</TargetName>
+    <IgnoreImportLibrary>true</IgnoreImportLibrary>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>.\build-$(Platform)\$(Configuration)\Bin\</OutDir>
+    <IntDir>.\build-$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>Candle</TargetName>
+    <IgnoreImportLibrary>true</IgnoreImportLibrary>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Label="QtSettings" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <QtInstall>msvc2017</QtInstall>
+    <QtModules>core;gui;network;opengl;serialport;widgets;winextras</QtModules>
+  </PropertyGroup>
+  <PropertyGroup Label="QtSettings" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <QtInstall>msvc2017</QtInstall>
+    <QtModules>core;gui;network;opengl;serialport;widgets;winextras</QtModules>
+  </PropertyGroup>
+  <ImportGroup Condition="Exists('$(QtMsBuild)\qt.props')">
+    <Import Project="$(QtMsBuild)\qt.props" />
+  </ImportGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>.\GeneratedFiles\$(ConfigurationName);.\GeneratedFiles;.;..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\include;..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\include\QtOpenGL;..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\include\QtWidgets;..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\include\QtWinExtras;..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\include\QtGui;..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\include\QtANGLE;..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\include\QtSerialPort;..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\include\QtCore;release;\include;..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\mkspecs\win32-msvc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>GeneratedFiles\$(ConfigurationName);GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\GeneratedFiles;.;release;\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>-Zc:rvalueCast -Zc:inline -Zc:strictStrings -Zc:throwingNew -Zc:referenceBinding -Zc:__cplusplus -w34100 -w34189 -w44996 -w44456 -w44457 -w44458 %(AdditionalOptions)</AdditionalOptions>
       <AssemblerListingLocation>release\</AssemblerListingLocation>
       <BrowseInformation>false</BrowseInformation>
@@ -76,7 +88,7 @@
       <ExceptionHandling>Sync</ExceptionHandling>
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <Optimization>MaxSpeed</Optimization>
-      <PreprocessorDefinitions>_WINDOWS;UNICODE;_UNICODE;WIN32;_ENABLE_EXTENDED_ALIGNED_STORAGE;WINDOWS;APP_VERSION="1.1.8";_USE_MATH_DEFINES;QT_NO_DEBUG;QT_OPENGL_LIB;QT_WIDGETS_LIB;QT_WINEXTRAS_LIB;QT_GUI_LIB;QT_SERIALPORT_LIB;QT_CORE_LIB;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WINDOWS;UNICODE;_UNICODE;WIN32;_ENABLE_EXTENDED_ALIGNED_STORAGE;WINDOWS;APP_VERSION="1.1.8";_USE_MATH_DEFINES;QT_NO_DEBUG;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessToFile>false</PreprocessToFile>
       <ProgramDataBaseFileName>$(IntDir)vc$(PlatformToolsetVersion).pdb</ProgramDataBaseFileName>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -84,10 +96,11 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <WarningLevel>Level3</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(QTDIR)\lib\Qt5OpenGL.lib;$(QTDIR)\lib\Qt5Widgets.lib;$(QTDIR)\lib\Qt5WinExtras.lib;$(QTDIR)\lib\Qt5Gui.lib;$(QTDIR)\lib\Qt5SerialPort.lib;$(QTDIR)\lib\Qt5Core.lib;$(QTDIR)\lib\qtmain.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(QTDIR)\lib;E:\QT\QT5.12.0\5.12.0\MSVC2017\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>"/MANIFESTDEPENDENCY:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' publicKeyToken='6595b64144ccf1df' language='*' processorArchitecture='*'" %(AdditionalOptions)</AdditionalOptions>
       <DataExecutionPrevention>true</DataExecutionPrevention>
       <GenerateDebugInformation>false</GenerateDebugInformation>
@@ -108,33 +121,28 @@
       <PreprocessorDefinitions>_WINDOWS;UNICODE;_UNICODE;WIN32;_ENABLE_EXTENDED_ALIGNED_STORAGE;WINDOWS;sNan="65536";APP_VERSION=\"1.1.8\";_USE_MATH_DEFINES;QT_NO_DEBUG;QT_OPENGL_LIB;QT_WIDGETS_LIB;QT_WINEXTRAS_LIB;QT_GUI_LIB;QT_SERIALPORT_LIB;QT_CORE_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <QtMoc>
-      <QTDIR>E:\QT\QT5.12.0\5.12.0\MSVC2017</QTDIR>
-      <OutputFile>.\build-$(Platform)\$(Configuration)\moc_%(Filename).cpp</OutputFile>
-      <Define>_WINDOWS;UNICODE;_UNICODE;WIN32;_ENABLE_EXTENDED_ALIGNED_STORAGE;WINDOWS;APP_VERSION="1.1.8";_USE_MATH_DEFINES;QT_NO_DEBUG;QT_OPENGL_LIB;QT_WIDGETS_LIB;QT_WINEXTRAS_LIB;QT_GUI_LIB;QT_SERIALPORT_LIB;QT_CORE_LIB;NDEBUG;%(PreprocessorDefinitions)</Define>
       <CompilerFlavor>msvc</CompilerFlavor>
       <Include>./$(Configuration)/moc_predefs.h</Include>
       <ExecutionDescription>Moc'ing %(Identity)...</ExecutionDescription>
-      <InputFile>%(FullPath)</InputFile>
       <DynamicSource>output</DynamicSource>
-      <IncludePath>.\GeneratedFiles\$(ConfigurationName);.\GeneratedFiles;E:/QT/QT5.12.0/5.12.0/MSVC2017/mkspecs/$(Platform)-msvc;.;E:/QT/QT5.12.0/5.12.0/MSVC2017/include;E:/QT/QT5.12.0/5.12.0/MSVC2017/include/QtOpenGL;E:/QT/QT5.12.0/5.12.0/MSVC2017/include/QtWidgets;E:/QT/QT5.12.0/5.12.0/MSVC2017/include/QtWinExtras;E:/QT/QT5.12.0/5.12.0/MSVC2017/include/QtGui;E:/QT/QT5.12.0/5.12.0/MSVC2017/include/QtANGLE;E:/QT/QT5.12.0/5.12.0/MSVC2017/include/QtSerialPort;E:/QT/QT5.12.0/5.12.0/MSVC2017/include/QtCore;C:\Program Files (x86)\Microsoft Visual Studio\VC98\atl\include;C:\Program Files (x86)\Microsoft Visual Studio\VC98\mfc\include;C:\Program Files (x86)\Microsoft Visual Studio\VC98\include;E:\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\ATLMFC\include;E:\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\include;C:\Program Files (x86)\Windows Kits\NETFXSDK\4.6.1\include\um;C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\ucrt;C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\shared;C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\um;C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\winrt;C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\cppwinrt</IncludePath>
+      <QtMocDir>.\build-$(Platform)\$(Configuration)</QtMocDir>
+      <QtMocFileName>moc_%(Filename).cpp</QtMocFileName>
     </QtMoc>
     <QtRcc>
-      <OutputFile>.\build-$(Platform)\$(Configuration)\qrc_%(Filename).cpp</OutputFile>
-      <QTDIR>E:\QT\QT5.12.0\5.12.0\MSVC2017</QTDIR>
       <Compression>default</Compression>
       <ExecutionDescription>Rcc'ing %(Identity)...</ExecutionDescription>
-      <InputFile>%(FullPath)</InputFile>
+      <QtRccDir>.\build-$(Platform)\$(Configuration)</QtRccDir>
+      <QtRccFileName>qrc_%(Filename).cpp</QtRccFileName>
     </QtRcc>
     <QtUic>
-      <QTDIR>E:\QT\QT5.12.0\5.12.0\MSVC2017</QTDIR>
       <ExecutionDescription>Uic'ing %(Identity)...</ExecutionDescription>
-      <InputFile>%(FullPath)</InputFile>
-      <OutputFile>.\build-$(Platform)\$(Configuration)\ui_%(Filename).h</OutputFile>
+      <QtUicDir>.\build-$(Platform)\$(Configuration)</QtUicDir>
+      <QtUicFileName>ui_%(Filename).h</QtUicFileName>
     </QtUic>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>.\GeneratedFiles\$(ConfigurationName);.\GeneratedFiles;.;..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\include;..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\include\QtOpenGL;..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\include\QtWidgets;..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\include\QtWinExtras;..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\include\QtGui;..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\include\QtANGLE;..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\include\QtSerialPort;..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\include\QtCore;debug;\include;..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\mkspecs\win32-msvc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>GeneratedFiles\$(ConfigurationName);GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\GeneratedFiles;.;debug;\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>-Zc:rvalueCast -Zc:inline -Zc:strictStrings -Zc:throwingNew -Zc:referenceBinding -Zc:__cplusplus -w34100 -w34189 -w44996 -w44456 -w44457 -w44458 %(AdditionalOptions)</AdditionalOptions>
       <AssemblerListingLocation>debug\</AssemblerListingLocation>
       <BrowseInformation>false</BrowseInformation>
@@ -143,7 +151,7 @@
       <ExceptionHandling>Sync</ExceptionHandling>
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_WINDOWS;UNICODE;_UNICODE;WIN32;_ENABLE_EXTENDED_ALIGNED_STORAGE;WINDOWS;APP_VERSION="1.1.8";_USE_MATH_DEFINES;QT_OPENGL_LIB;QT_WIDGETS_LIB;QT_WINEXTRAS_LIB;QT_GUI_LIB;QT_SERIALPORT_LIB;QT_CORE_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WINDOWS;UNICODE;_UNICODE;WIN32;_ENABLE_EXTENDED_ALIGNED_STORAGE;WINDOWS;APP_VERSION="1.1.8";_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessToFile>false</PreprocessToFile>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -151,10 +159,11 @@
       <WarningLevel>Level3</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ProgramDataBaseFileName>$(IntDir)vc$(PlatformToolsetVersion).pdb</ProgramDataBaseFileName>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(QTDIR)\lib\Qt5OpenGLd.lib;$(QTDIR)\lib\Qt5Widgetsd.lib;$(QTDIR)\lib\Qt5WinExtrasd.lib;$(QTDIR)\lib\Qt5Guid.lib;$(QTDIR)\lib\Qt5SerialPortd.lib;$(QTDIR)\lib\Qt5Cored.lib;$(QTDIR)\lib\qtmaind.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(QTDIR)\lib;E:\QT\QT5.12.0\5.12.0\MSVC2017\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>"/MANIFESTDEPENDENCY:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' publicKeyToken='6595b64144ccf1df' language='*' processorArchitecture='*'" %(AdditionalOptions)</AdditionalOptions>
       <DataExecutionPrevention>true</DataExecutionPrevention>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -174,28 +183,23 @@
       <PreprocessorDefinitions>_WINDOWS;UNICODE;_UNICODE;WIN32;_ENABLE_EXTENDED_ALIGNED_STORAGE;WINDOWS;APP_VERSION=\"1.1.8\";_USE_MATH_DEFINES;QT_OPENGL_LIB;QT_WIDGETS_LIB;QT_WINEXTRAS_LIB;QT_GUI_LIB;QT_SERIALPORT_LIB;QT_CORE_LIB;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <QtMoc>
-      <QTDIR>E:\QT\QT5.12.0\5.12.0\MSVC2017</QTDIR>
-      <OutputFile>.\build-$(Platform)\$(Configuration)\moc_%(Filename).cpp</OutputFile>
-      <Define>_WINDOWS;UNICODE;_UNICODE;WIN32;_ENABLE_EXTENDED_ALIGNED_STORAGE;WINDOWS;APP_VERSION="1.1.8";_USE_MATH_DEFINES;QT_OPENGL_LIB;QT_WIDGETS_LIB;QT_WINEXTRAS_LIB;QT_GUI_LIB;QT_SERIALPORT_LIB;QT_CORE_LIB;%(PreprocessorDefinitions)</Define>
       <CompilerFlavor>msvc</CompilerFlavor>
       <Include>./$(Configuration)/moc_predefs.h</Include>
       <ExecutionDescription>Moc'ing %(Identity)...</ExecutionDescription>
-      <InputFile>%(FullPath)</InputFile>
       <DynamicSource>output</DynamicSource>
-      <IncludePath>.\GeneratedFiles\$(ConfigurationName);.\GeneratedFiles;E:/QT/QT5.12.0/5.12.0/MSVC2017/mkspecs/$(Platform)-msvc;.;E:/QT/QT5.12.0/5.12.0/MSVC2017/include;E:/QT/QT5.12.0/5.12.0/MSVC2017/include/QtOpenGL;E:/QT/QT5.12.0/5.12.0/MSVC2017/include/QtWidgets;E:/QT/QT5.12.0/5.12.0/MSVC2017/include/QtWinExtras;E:/QT/QT5.12.0/5.12.0/MSVC2017/include/QtGui;E:/QT/QT5.12.0/5.12.0/MSVC2017/include/QtANGLE;E:/QT/QT5.12.0/5.12.0/MSVC2017/include/QtSerialPort;E:/QT/QT5.12.0/5.12.0/MSVC2017/include/QtCore;C:\Program Files (x86)\Microsoft Visual Studio\VC98\atl\include;C:\Program Files (x86)\Microsoft Visual Studio\VC98\mfc\include;C:\Program Files (x86)\Microsoft Visual Studio\VC98\include;E:\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\ATLMFC\include;E:\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\include;C:\Program Files (x86)\Windows Kits\NETFXSDK\4.6.1\include\um;C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\ucrt;C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\shared;C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\um;C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\winrt;C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\cppwinrt</IncludePath>
+      <QtMocDir>.\build-$(Platform)\$(Configuration)</QtMocDir>
+      <QtMocFileName>moc_%(Filename).cpp</QtMocFileName>
     </QtMoc>
     <QtRcc>
       <Compression>default</Compression>
-      <OutputFile>.\build-$(Platform)\$(Configuration)\qrc_%(Filename).cpp</OutputFile>
-      <QTDIR>E:\QT\QT5.12.0\5.12.0\MSVC2017</QTDIR>
       <ExecutionDescription>Rcc'ing %(Identity)...</ExecutionDescription>
-      <InputFile>%(FullPath)</InputFile>
+      <QtRccDir>.\build-$(Platform)\$(Configuration)</QtRccDir>
+      <QtRccFileName>qrc_%(Filename).cpp</QtRccFileName>
     </QtRcc>
     <QtUic>
-      <QTDIR>E:\QT\QT5.12.0\5.12.0\MSVC2017</QTDIR>
       <ExecutionDescription>Uic'ing %(Identity)...</ExecutionDescription>
-      <InputFile>%(FullPath)</InputFile>
-      <OutputFile>.\build-$(Platform)\$(Configuration)\ui_%(Filename).h</OutputFile>
+      <QtUicDir>.\build-$(Platform)\$(Configuration)</QtUicDir>
+      <QtUicFileName>ui_%(Filename).h</QtUicFileName>
     </QtUic>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -232,67 +236,50 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="parser\arcproperties.h" />
-    <QtMoc Include="widgets\colorpicker.h">
-    </QtMoc>
-    <QtMoc Include="widgets\combobox.h">
-    </QtMoc>
+    <QtMoc Include="widgets\colorpicker.h" />
+    <QtMoc Include="widgets\combobox.h" />
     <ClInclude Include="widgets\comboboxkey.h" />
-    <QtMoc Include="frmabout.h">
-    </QtMoc>
-    <QtMoc Include="frmmain.h">
-    </QtMoc>
-    <QtMoc Include="frmsettings.h">
-    </QtMoc>
-    <QtMoc Include="drawers\gcodedrawer.h">
-    </QtMoc>
-    <QtMoc Include="parser\gcodeparser.h">
-    </QtMoc>
-    <QtMoc Include="parser\gcodepreprocessorutils.h">
-    </QtMoc>
-    <QtMoc Include="tables\gcodetablemodel.h">
-    </QtMoc>
-    <QtMoc Include="parser\gcodeviewparse.h">
-    </QtMoc>
-    <QtMoc Include="widgets\glwidget.h">
-    </QtMoc>
-    <QtMoc Include="widgets\groupbox.h">
-    </QtMoc>
+    <QtMoc Include="frmabout.h" />
+    <QtMoc Include="frmmain.h" />
+    <QtMoc Include="frmsettings.h" />
+    <QtMoc Include="drawers\gcodedrawer.h" />
+    <QtMoc Include="parser\gcodeparser.h" />
+    <QtMoc Include="parser\gcodepreprocessorutils.h" />
+    <QtMoc Include="tables\gcodetablemodel.h" />
+    <QtMoc Include="parser\gcodeviewparse.h" />
+    <QtMoc Include="widgets\glwidget.h" />
+    <QtMoc Include="widgets\groupbox.h" />
     <ClInclude Include="drawers\heightmapborderdrawer.h" />
     <ClInclude Include="drawers\heightmapgriddrawer.h" />
     <ClInclude Include="drawers\heightmapinterpolationdrawer.h" />
-    <QtMoc Include="tables\heightmaptablemodel.h">
-    </QtMoc>
+    <QtMoc Include="tables\heightmaptablemodel.h" />
     <ClInclude Include="utils\interpolation.h" />
     <ClInclude Include="parser\linesegment.h" />
     <ClInclude Include="drawers\origindrawer.h" />
     <ClInclude Include="parser\pointsegment.h" />
-    <QtMoc Include="widgets\scrollarea.h">
-    </QtMoc>
+    <QtMoc Include="widgets\scrollarea.h" />
     <ClInclude Include="drawers\selectiondrawer.h" />
     <ClInclude Include="drawers\shaderdrawable.h" />
-    <QtMoc Include="widgets\slider.h">
-    </QtMoc>
-    <QtMoc Include="widgets\sliderbox.h">
-    </QtMoc>
+    <QtMoc Include="widgets\slider.h" />
+    <QtMoc Include="widgets\sliderbox.h" />
     <ClInclude Include="widgets\styledtoolbutton.h" />
     <ClInclude Include="drawers\tooldrawer.h" />
     <ClInclude Include="utils\util.h" />
-    <QtMoc Include="widgets\widget.h">
-    </QtMoc>
+    <QtMoc Include="widgets\widget.h" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="debug\moc_predefs.h.cbt">
       <FileType>Document</FileType>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\mkspecs\features\data\dummy.cpp;%(AdditionalInputs)</AdditionalInputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">cl -Bx"$(QTDIR)\bin\qmake.exe" -nologo -Zc:wchar_t -FS -Zc:rvalueCast -Zc:inline -Zc:strictStrings -Zc:throwingNew -Zc:referenceBinding -Zc:__cplusplus -Zi -MDd -g3 -pg -W3 -w34100 -w34189 -w44996 -w44456 -w44457 -w44458 -wd4577 -wd4467 -E ..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\mkspecs\features\data\dummy.cpp 2&gt;NUL &gt;debug\moc_predefs.h</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(QTDIR)\mkspecs\features\data\dummy.cpp;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">cl -Bx"$(QTDIR)\bin\qmake.exe" -nologo -Zc:wchar_t -FS -Zc:rvalueCast -Zc:inline -Zc:strictStrings -Zc:throwingNew -Zc:referenceBinding -Zc:__cplusplus -Zi -MDd -g3 -pg -W3 -w34100 -w34189 -w44996 -w44456 -w44457 -w44458 -wd4577 -wd4467 -E $(QTDIR)\mkspecs\features\data\dummy.cpp 2&gt;NUL &gt;debug\moc_predefs.h</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Generate moc_predefs.h</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">debug\moc_predefs.h;%(Outputs)</Outputs>
     </CustomBuild>
     <CustomBuild Include="release\moc_predefs.h.cbt">
       <FileType>Document</FileType>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\mkspecs\features\data\dummy.cpp;%(AdditionalInputs)</AdditionalInputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">cl -Bx"$(QTDIR)\bin\qmake.exe" -nologo -Zc:wchar_t -FS -Zc:rvalueCast -Zc:inline -Zc:strictStrings -Zc:throwingNew -Zc:referenceBinding -Zc:__cplusplus -O2 -MD -W3 -w34100 -w34189 -w44996 -w44456 -w44457 -w44458 -wd4577 -wd4467 -E ..\..\..\QT\QT5.12.0\5.12.0\MSVC2017\mkspecs\features\data\dummy.cpp 2&gt;NUL &gt;release\moc_predefs.h</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(QTDIR)\mkspecs\features\data\dummy.cpp;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">cl -Bx"$(QTDIR)\bin\qmake.exe" -nologo -Zc:wchar_t -FS -Zc:rvalueCast -Zc:inline -Zc:strictStrings -Zc:throwingNew -Zc:referenceBinding -Zc:__cplusplus -O2 -MD -W3 -w34100 -w34189 -w44996 -w44456 -w44457 -w44458 -wd4577 -wd4467 -E $(QTDIR)\mkspecs\features\data\dummy.cpp 2&gt;NUL &gt;release\moc_predefs.h</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Generate moc_predefs.h</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">release\moc_predefs.h;%(Outputs)</Outputs>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
@@ -310,20 +297,20 @@
   </ItemGroup>
   <ItemGroup>
     <QtUic Include="frmabout.ui">
-      <OutputFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">ui_frmabout.h</OutputFile>
-      <OutputFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">ui_frmabout.h</OutputFile>
+      <QtUicDir>$(ProjectDir)</QtUicDir>
+      <QtUicFileName>ui_frmabout.h</QtUicFileName>
     </QtUic>
     <QtUic Include="frmmain.ui">
-      <OutputFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">ui_frmmain.h</OutputFile>
-      <OutputFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">ui_frmmain.h</OutputFile>
+      <QtUicDir>$(ProjectDir)</QtUicDir>
+      <QtUicFileName>ui_frmmain.h</QtUicFileName>
     </QtUic>
     <QtUic Include="frmsettings.ui">
-      <OutputFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">ui_frmsettings.h</OutputFile>
-      <OutputFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">ui_frmsettings.h</OutputFile>
+      <QtUicDir>$(ProjectDir)</QtUicDir>
+      <QtUicFileName>ui_frmsettings.h</QtUicFileName>
     </QtUic>
     <QtUic Include="widgets\sliderbox.ui">
-      <OutputFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">ui_sliderbox.h</OutputFile>
-      <OutputFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">ui_sliderbox.h</OutputFile>
+      <QtUicDir>$(ProjectDir)</QtUicDir>
+      <QtUicFileName>ui_sliderbox.h</QtUicFileName>
     </QtUic>
   </ItemGroup>
   <ItemGroup>
@@ -382,9 +369,11 @@
     <None Include="shaders\vshader.glsl" />
     <None Include="images\zero_z.png" />
   </ItemGroup>
+  <!--
   <ItemGroup>
     <ResourceCompile Include=".\Candle_resource.rc" />
   </ItemGroup>
+-->
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Condition="Exists('$(QtMsBuild)\qt.targets')">
     <Import Project="$(QtMsBuild)\qt.targets" />
@@ -392,7 +381,7 @@
   <ImportGroup Label="ExtensionTargets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties UicDir="$(Configuration)" Qt5Version_x0020_Win32="msvc2017" />
+      <UserProperties />
     </VisualStudio>
   </ProjectExtensions>
 </Project>

--- a/src/frmmain.cpp
+++ b/src/frmmain.cpp
@@ -344,7 +344,6 @@ void frmMain::loadSettings()
     m_settings->setPort(set.value("port").toString());
     m_settings->setBaud(set.value("baud").toInt());
     m_settings->setSerialHostname(set.value("serialHostname").toString());
-    m_settings->setSerialTcpPort(set.value("serialTcpPort").toInt());
     m_settings->setIgnoreErrors(set.value("ignoreErrors", false).toBool());
     m_settings->setAutoLine(set.value("autoLine", true).toBool());
     m_settings->setToolDiameter(set.value("toolDiameter", 3).toDouble());
@@ -497,7 +496,6 @@ void frmMain::saveSettings()
     set.setValue("port", m_settings->port());
     set.setValue("baud", m_settings->baud());
     set.setValue("serialHostname", m_settings->serialHostname());
-    set.setValue("serialTcpPort", m_settings->serialTcpPort());
     set.setValue("ignoreErrors", m_settings->ignoreErrors());
     set.setValue("autoLine", m_settings->autoLine());
     set.setValue("toolDiameter", m_settings->toolDiameter());
@@ -2205,16 +2203,15 @@ void frmMain::on_actServiceSettings_triggered()
     if (m_settings->exec()) {
         qDebug() << "Applying settings";
         qDebug() << "Port:" << m_settings->port() << "Baud:" << m_settings->baud();
-        qDebug() << "Hostname:" << m_settings->serialHostname() << "TCPPort:" << m_settings->serialTcpPort();
+        qDebug() << "Hostname:" << m_settings->serialHostname() << ":" << m_settings->serialTcpPort();
 
-        if (m_settings->serialHostname() != "" && (m_settings->serialHostname() != m_serialSocket.peerName() ||
+        if (!m_settings->serialHostname().isEmpty() && (m_settings->serialHostname() != m_serialSocket.peerName() ||
             m_settings->serialTcpPort() != m_serialSocket.peerPort())) {
-            if (m_serialSocket.isOpen()) m_serialSocket.close();
-            openPort();
-        }
-
-        if (m_settings->port() != "" && (m_settings->port() != m_serialPort.portName() ||
-                                           m_settings->baud() != m_serialPort.baudRate())) {
+            if (m_serialSocket.isOpen())
+                m_serialSocket.close();
+            // The socket will be reconnected in the timer event handler
+        } else if (!m_settings->port().isEmpty() && (m_settings->port() != m_serialPort.portName() ||
+            m_settings->baud() != m_serialPort.baudRate())) {
             if (m_serialPort.isOpen()) m_serialPort.close();
             m_serialPort.setPortName(m_settings->port());
             m_serialPort.setBaudRate(m_settings->baud());

--- a/src/frmmain.cpp
+++ b/src/frmmain.cpp
@@ -264,9 +264,16 @@ frmMain::frmMain(QWidget *parent) :
         m_serialPort.setPortName(m_settings->port());
         m_serialPort.setBaudRate(m_settings->baud());
     }
+    // Setup TCP socket
+    //  set the socket to low delay to avoid too much buffering
+    //  since it's expected the connection to be on a local network where congestion is not an issue
+    m_serialSocket.setSocketOption(QAbstractSocket::SocketOption::LowDelayOption, 1);
 
     connect(&m_serialPort, SIGNAL(readyRead()), this, SLOT(onSerialPortReadyRead()), Qt::QueuedConnection);
     connect(&m_serialPort, SIGNAL(error(QSerialPort::SerialPortError)), this, SLOT(onSerialPortError(QSerialPort::SerialPortError)));
+    connect(&m_serialSocket, SIGNAL(readyRead()), this, SLOT(onSerialPortReadyRead()), Qt::QueuedConnection);
+    connect(&m_serialSocket, SIGNAL(connected()), this, SLOT(onSerialSocketConnected()), Qt::QueuedConnection);
+    connect(&m_serialSocket, SIGNAL(errorOccured(QAbstractSocket::SocketError)), this, SLOT(onSerialSocketError(QAbstractSocket::SocketError)));
 
     this->installEventFilter(this);
     ui->tblProgram->installEventFilter(this);
@@ -336,6 +343,8 @@ void frmMain::loadSettings()
     m_settings->setFontSize(set.value("fontSize", 8).toInt());
     m_settings->setPort(set.value("port").toString());
     m_settings->setBaud(set.value("baud").toInt());
+    m_settings->setSerialHostname(set.value("serialHostname").toString());
+    m_settings->setSerialTcpPort(set.value("serialTcpPort").toInt());
     m_settings->setIgnoreErrors(set.value("ignoreErrors", false).toBool());
     m_settings->setAutoLine(set.value("autoLine", true).toBool());
     m_settings->setToolDiameter(set.value("toolDiameter", 3).toDouble());
@@ -487,6 +496,8 @@ void frmMain::saveSettings()
 
     set.setValue("port", m_settings->port());
     set.setValue("baud", m_settings->baud());
+    set.setValue("serialHostname", m_settings->serialHostname());
+    set.setValue("serialTcpPort", m_settings->serialTcpPort());
     set.setValue("ignoreErrors", m_settings->ignoreErrors());
     set.setValue("autoLine", m_settings->autoLine());
     set.setValue("toolDiameter", m_settings->toolDiameter());
@@ -622,7 +633,7 @@ bool frmMain::saveChanges(bool heightMapMode)
 }
 
 void frmMain::updateControlsState() {
-    bool portOpened = m_serialPort.isOpen();
+    bool portOpened = getIODevice().isOpen();
 
     ui->grpState->setEnabled(portOpened);
     ui->grpControl->setEnabled(portOpened);
@@ -728,6 +739,10 @@ void frmMain::updateControlsState() {
 
 void frmMain::openPort()
 {
+    // Don't open serial port if already connected/connecting via TCP
+    if (m_serialSocket.state() != QAbstractSocket::SocketState::UnconnectedState
+        && m_serialSocket.state() != QAbstractSocket::SocketState::ClosingState)
+        return;
     if (m_serialPort.open(QIODevice::ReadWrite)) {
         ui->txtStatus->setText(tr("Port opened"));
         ui->txtStatus->setStyleSheet(QString("background-color: palette(button); color: palette(text);"));
@@ -738,7 +753,7 @@ void frmMain::openPort()
 
 void frmMain::sendCommand(QString command, int tableIndex, bool showInConsole)
 {
-    if (!m_serialPort.isOpen() || !m_resetCompleted) return;
+    if (!getIODevice().isOpen() || !m_resetCompleted) return;
 
     command = command.toUpper();
 
@@ -787,14 +802,14 @@ void frmMain::sendCommand(QString command, int tableIndex, bool showInConsole)
         m_fileEndSent = true;
     }
 
-    m_serialPort.write((command + "\r").toLatin1());
+    getIODevice().write((command + "\r").toLatin1());
 }
 
 void frmMain::grblReset()
 {
     qDebug() << "grbl reset";
 
-    m_serialPort.write(QByteArray(1, (char)24));
+    getIODevice().write(QByteArray(1, (char)24));
 //    m_serialPort.flush();
 
     m_processingFile = false;
@@ -837,8 +852,9 @@ int frmMain::bufferLength()
 
 void frmMain::onSerialPortReadyRead()
 {
-    while (m_serialPort.canReadLine()) {
-        QString data = m_serialPort.readLine().trimmed();
+    auto& ioDevice = getIODevice();
+    while (ioDevice.canReadLine()) {
+        QString data = ioDevice.readLine().trimmed();
 
         // Filter prereset responses
         if (m_reseting) {
@@ -1042,13 +1058,13 @@ void frmMain::onSerialPortReadyRead()
 
                 if (rapid != target) switch (target) {
                 case 25:
-                    m_serialPort.write(QByteArray(1, char(0x97)));
+                    getIODevice().write(QByteArray(1, char(0x97)));
                     break;
                 case 50:
-                    m_serialPort.write(QByteArray(1, char(0x96)));
+                    getIODevice().write(QByteArray(1, char(0x96)));
                     break;
                 case 100:
-                    m_serialPort.write(QByteArray(1, char(0x95)));
+                    getIODevice().write(QByteArray(1, char(0x95)));
                     break;
                 }
 
@@ -1271,7 +1287,7 @@ void frmMain::onSerialPortReadyRead()
                                 holding = true;         // Hold transmit while messagebox is visible
                                 response.clear();
 
-                                m_serialPort.write("!");
+                                getIODevice().write("!");
                                 m_senderErrorBox->checkBox()->setChecked(false);
                                 qApp->beep();
                                 int result = m_senderErrorBox->exec();
@@ -1279,7 +1295,7 @@ void frmMain::onSerialPortReadyRead()
                                 holding = false;
                                 errors.clear();
                                 if (m_senderErrorBox->checkBox()->isChecked()) m_settings->setIgnoreErrors(true);
-                                if (result == QMessageBox::Ignore) m_serialPort.write("~"); else on_cmdFileAbort_clicked();
+                                if (result == QMessageBox::Ignore) getIODevice().write("~"); else on_cmdFileAbort_clicked();
                             }
                         }
 
@@ -1380,10 +1396,37 @@ void frmMain::onSerialPortError(QSerialPort::SerialPortError error)
     }
 }
 
+void frmMain::onSerialSocketConnected()
+{
+    ui->txtStatus->setText(tr("TCP serial opened"));
+    ui->txtStatus->setStyleSheet(QString("background-color: palette(button); color: palette(text);"));
+    //        updateControlsState();
+    grblReset();
+}
+
+void frmMain::onSerialSocketError(QAbstractSocket::SocketError socketError)
+{
+    static QAbstractSocket::SocketError previousSocketError;
+
+    if (socketError != previousSocketError) {
+        previousSocketError = socketError;
+        ui->txtConsole->appendPlainText(tr("TCP Socket error ") + QString::number(socketError) + ": " + m_serialSocket.errorString());
+        if (m_serialSocket.isOpen()) {
+            m_serialSocket.close();
+            updateControlsState();
+        }
+    }
+}
+
 void frmMain::onTimerConnection()
 {
-    if (!m_serialPort.isOpen()) {
-        openPort();
+    if (m_serialSocket.state() == QAbstractSocket::SocketState::UnconnectedState && !m_serialPort.isOpen()) {
+        if (m_serialSocket.state() == QAbstractSocket::SocketState::UnconnectedState && m_settings->serialHostname() != "") {
+            m_serialSocket.connectToHost(m_settings->serialHostname(), m_settings->serialTcpPort());
+        }
+        else {
+            openPort();
+        }
     } else if (!m_homing/* && !m_reseting*/ && !ui->cmdFilePause->isChecked() && m_queue.length() == 0) {
         if (m_updateSpindleSpeed) {
             m_updateSpindleSpeed = false;
@@ -1398,8 +1441,9 @@ void frmMain::onTimerConnection()
 
 void frmMain::onTimerStateQuery()
 {
-    if (m_serialPort.isOpen() && m_resetCompleted && m_statusReceived) {
-        m_serialPort.write(QByteArray(1, '?'));
+    auto& ioDevice = getIODevice();
+    if (ioDevice.isOpen() && m_resetCompleted && m_statusReceived) {
+        ioDevice.write(QByteArray(1, '?'));
         m_statusReceived = false;
     }
 
@@ -1549,7 +1593,8 @@ void frmMain::closeEvent(QCloseEvent *ce)
         return;
     }
 
-    if (m_serialPort.isOpen()) m_serialPort.close();
+    auto& ioDevice = getIODevice();
+    if (ioDevice.isOpen()) ioDevice.close();
     if (m_queue.length() > 0) {
         m_commands.clear();
         m_queue.clear();
@@ -1983,7 +2028,7 @@ void frmMain::on_cmdFileAbort_clicked()
 {
     m_aborting = true;
     if (!ui->chkTestMode->isChecked()) {
-        m_serialPort.write("!");
+        getIODevice().write("!");
     } else {
         grblReset();
     }
@@ -2160,6 +2205,13 @@ void frmMain::on_actServiceSettings_triggered()
     if (m_settings->exec()) {
         qDebug() << "Applying settings";
         qDebug() << "Port:" << m_settings->port() << "Baud:" << m_settings->baud();
+        qDebug() << "Hostname:" << m_settings->serialHostname() << "TCPPort:" << m_settings->serialTcpPort();
+
+        if (m_settings->serialHostname() != "" && (m_settings->serialHostname() != m_serialSocket.peerName() ||
+            m_settings->serialTcpPort() != m_serialSocket.peerPort())) {
+            if (m_serialSocket.isOpen()) m_serialSocket.close();
+            openPort();
+        }
 
         if (m_settings->port() != "" && (m_settings->port() != m_serialPort.portName() ||
                                            m_settings->baud() != m_serialPort.baudRate())) {
@@ -2452,7 +2504,7 @@ void frmMain::on_cmdSpindle_toggled(bool checked)
 void frmMain::on_cmdSpindle_clicked(bool checked)
 {
     if (ui->cmdFilePause->isChecked()) {
-        m_serialPort.write(QByteArray(1, char(0x9e)));
+        getIODevice().write(QByteArray(1, char(0x9e)));
     } else {
         sendCommand(checked ? QString("M3 S%1").arg(ui->slbSpindle->value()) : "M5", -1, m_settings->showUICommands());
     }
@@ -2472,7 +2524,7 @@ void frmMain::on_chkTestMode_clicked(bool checked)
 
 void frmMain::on_cmdFilePause_clicked(bool checked)
 {
-    m_serialPort.write(checked ? "!" : "~");
+    getIODevice().write(checked ? "!" : "~");
 }
 
 void frmMain::on_cmdFileReset_clicked()
@@ -3861,9 +3913,9 @@ void frmMain::updateOverride(SliderBox *slider, int value, char command)
     bool smallStep = abs(target - slider->currentValue()) < 10 || m_settings->queryStateTime() < 100;
 
     if (slider->currentValue() < target) {
-        m_serialPort.write(QByteArray(1, char(smallStep ? command + 2 : command)));
+        getIODevice().write(QByteArray(1, char(smallStep ? command + 2 : command)));
     } else if (slider->currentValue() > target) {
-        m_serialPort.write(QByteArray(1, char(smallStep ? command + 3 : command + 1)));
+        getIODevice().write(QByteArray(1, char(smallStep ? command + 3 : command + 1)));
     }
 }
 
@@ -3898,6 +3950,13 @@ void frmMain::jogStep()
                     .arg(vec.z(), 0, 'g', 4)
                     .arg(speed), -3, m_settings->showUICommands());
     }
+}
+
+QIODevice& frmMain::getIODevice()
+{
+    if (m_serialSocket.isOpen())
+        return m_serialSocket;
+    return m_serialPort;
 }
 
 void frmMain::on_cmdYPlus_pressed()
@@ -3975,5 +4034,5 @@ void frmMain::on_cmdZMinus_released()
 void frmMain::on_cmdStop_clicked()
 {
     m_queue.clear();
-    m_serialPort.write(QByteArray(1, char(0x85)));
+    getIODevice().write(QByteArray(1, char(0x85)));
 }

--- a/src/frmmain.h
+++ b/src/frmmain.h
@@ -6,6 +6,7 @@
 
 #include <QMainWindow>
 #include <QtSerialPort/QSerialPort>
+#include <QTcpSocket>
 #include <QSettings>
 #include <QTimer>
 #include <QBasicTimer>
@@ -91,6 +92,8 @@ private slots:
 
     void onSerialPortReadyRead();
     void onSerialPortError(QSerialPort::SerialPortError);
+    void onSerialSocketConnected();
+    void onSerialSocketError(QAbstractSocket::SocketError socketError);
     void onTimerConnection();
     void onTimerStateQuery();
     void onVisualizatorRotationChanged();
@@ -232,6 +235,8 @@ private:
     bool m_settingsLoading;
 
     QSerialPort m_serialPort;
+    QTcpSocket m_serialSocket;
+    QIODevice& getIODevice();
 
     frmSettings *m_settings;
     frmAbout m_frmAbout;

--- a/src/frmsettings.cpp
+++ b/src/frmsettings.cpp
@@ -28,6 +28,7 @@ frmSettings::frmSettings(QWidget *parent) :
 
     ui->listCategories->item(0)->setSelected(true);
     connect(ui->scrollSettings->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(onScrollBarValueChanged(int)));
+    connect(ui->hostEdit, SIGNAL(textChanged(QString)), this, SLOT(onHostnameEdited(QString)));
 
     searchPorts();
 }
@@ -585,20 +586,33 @@ void frmSettings::setAutoLine(bool value)
 
 QString frmSettings::serialHostname()
 {
-    return "cncpi.lan";
+    auto hostname = ui->hostEdit->text();
+    auto parts = hostname.splitRef(':');
+    if (parts.length() == 2) {
+        return parts[0].toString();
+    }
+    return hostname;
 }
 
 void frmSettings::setSerialHostname(QString hostName)
 {
+    ui->hostEdit->setText(hostName);
 }
 
 int frmSettings::serialTcpPort()
 {
+    auto hostname = this->serialHostname();
+    if (hostname.isEmpty())
+        return -1;
+    auto parts = hostname.splitRef(':');
+    if (parts.length() == 2) {
+        auto portRef = parts[1];
+        bool ok;
+        auto port = portRef.toInt(&ok);
+        if (ok)
+            return port;
+    }
     return 6778;
-}
-
-void frmSettings::setSerialTcpPort(int port)
-{
 }
 
 void frmSettings::showEvent(QShowEvent *se)
@@ -733,4 +747,15 @@ void frmSettings::on_radGrayscaleS_toggled(bool checked)
 void frmSettings::on_radGrayscaleZ_toggled(bool checked)
 {
     ui->radGrayscaleS->setChecked(!checked);
+}
+
+void frmSettings::onHostnameEdited(const QString& newValue)
+{
+    if (newValue.isEmpty()) {
+        ui->cboPort->setEnabled(true);
+        ui->cboBaud->setEnabled(true);
+    } else {
+        ui->cboPort->setEnabled(false);
+        ui->cboBaud->setEnabled(false);
+    }
 }

--- a/src/frmsettings.cpp
+++ b/src/frmsettings.cpp
@@ -583,6 +583,24 @@ void frmSettings::setAutoLine(bool value)
     ui->chkAutoLine->setChecked(value);
 }
 
+QString frmSettings::serialHostname()
+{
+    return "cncpi.lan";
+}
+
+void frmSettings::setSerialHostname(QString hostName)
+{
+}
+
+int frmSettings::serialTcpPort()
+{
+    return 6778;
+}
+
+void frmSettings::setSerialTcpPort(int port)
+{
+}
+
 void frmSettings::showEvent(QShowEvent *se)
 {
     Q_UNUSED(se)

--- a/src/frmsettings.h
+++ b/src/frmsettings.h
@@ -117,6 +117,10 @@ public:
     void setIgnoreErrors(bool value);
     bool autoLine();
     void setAutoLine(bool value);
+    QString serialHostname();
+    void setSerialHostname(QString hostName);
+    int serialTcpPort();
+    void setSerialTcpPort(int port);
 
 protected:
     void showEvent(QShowEvent *se);

--- a/src/frmsettings.h
+++ b/src/frmsettings.h
@@ -120,13 +120,13 @@ public:
     QString serialHostname();
     void setSerialHostname(QString hostName);
     int serialTcpPort();
-    void setSerialTcpPort(int port);
 
 protected:
     void showEvent(QShowEvent *se);
 
 private slots:
     void onScrollBarValueChanged(int value);
+    void onHostnameEdited(const QString& newValue);
 
     void on_cmdRefresh_clicked();
     void on_cmdOK_clicked();

--- a/src/frmsettings.ui
+++ b/src/frmsettings.ui
@@ -72,8 +72,8 @@ QGroupBox {
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>436</width>
-          <height>1749</height>
+          <width>368</width>
+          <height>1571</height>
          </rect>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -84,11 +84,14 @@ QGroupBox {
            </property>
            <layout class="QVBoxLayout" name="verticalLayout">
             <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,1,0,0,1">
+             <layout class="QHBoxLayout" name="serialPortLayout" stretch="0,1,0,0,1">
               <item>
                <widget class="QLabel" name="label">
                 <property name="text">
                  <string>Port:</string>
+                </property>
+                <property name="buddy">
+                 <cstring>cboPort</cstring>
                 </property>
                </widget>
               </item>
@@ -123,6 +126,9 @@ QGroupBox {
                <widget class="QLabel" name="label_2">
                 <property name="text">
                  <string>Baud:</string>
+                </property>
+                <property name="buddy">
+                 <cstring>cboBaud</cstring>
                 </property>
                </widget>
               </item>
@@ -164,6 +170,27 @@ QGroupBox {
                   <string>115200</string>
                  </property>
                 </item>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_5">
+              <item>
+               <widget class="QLabel" name="label_8">
+                <property name="text">
+                 <string>Hostname:</string>
+                </property>
+                <property name="buddy">
+                 <cstring>hostEdit</cstring>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLineEdit" name="hostEdit">
+                <property name="toolTip">
+                 <string>Connect to a remote server (HOST:PORT syntax)</string>
+                </property>
                </widget>
               </item>
              </layout>
@@ -224,6 +251,9 @@ QGroupBox {
                <widget class="QLabel" name="label_11">
                 <property name="text">
                  <string>Status query period:</string>
+                </property>
+                <property name="buddy">
+                 <cstring>txtQueryStateTime</cstring>
                 </property>
                </widget>
               </item>
@@ -286,12 +316,18 @@ QGroupBox {
                 <property name="text">
                  <string>Units:</string>
                 </property>
+                <property name="buddy">
+                 <cstring>cboUnits</cstring>
+                </property>
                </widget>
               </item>
               <item row="1" column="0">
                <widget class="QLabel" name="label_10">
                 <property name="text">
                  <string>Rapid speed:</string>
+                </property>
+                <property name="buddy">
+                 <cstring>txtRapidSpeed</cstring>
                 </property>
                </widget>
               </item>
@@ -318,6 +354,9 @@ QGroupBox {
                 <property name="text">
                  <string>Acceleration:</string>
                 </property>
+                <property name="buddy">
+                 <cstring>txtAcceleration</cstring>
+                </property>
                </widget>
               </item>
               <item row="1" column="4">
@@ -343,12 +382,18 @@ QGroupBox {
                 <property name="text">
                  <string>max.:</string>
                 </property>
+                <property name="buddy">
+                 <cstring>txtSpindleSpeedMax</cstring>
+                </property>
                </widget>
               </item>
               <item row="2" column="0">
                <widget class="QLabel" name="label_12">
                 <property name="text">
                  <string>Spindle speed min.:</string>
+                </property>
+                <property name="buddy">
+                 <cstring>txtSpindleSpeedMin</cstring>
                 </property>
                </widget>
               </item>
@@ -375,6 +420,9 @@ QGroupBox {
                 <property name="text">
                  <string>Laser power min.:</string>
                 </property>
+                <property name="buddy">
+                 <cstring>txtLaserPowerMin</cstring>
+                </property>
                </widget>
               </item>
               <item row="3" column="1">
@@ -399,6 +447,9 @@ QGroupBox {
                <widget class="QLabel" name="label_35">
                 <property name="text">
                  <string>max.:</string>
+                </property>
+                <property name="buddy">
+                 <cstring>txtLaserPowerMax</cstring>
                 </property>
                </widget>
               </item>
@@ -442,6 +493,9 @@ QGroupBox {
               <property name="indent">
                <number>0</number>
               </property>
+              <property name="buddy">
+               <cstring>txtTouchCommand</cstring>
+              </property>
              </widget>
             </item>
             <item>
@@ -464,6 +518,9 @@ QGroupBox {
               </property>
               <property name="indent">
                <number>0</number>
+              </property>
+              <property name="buddy">
+               <cstring>txtSafeCommand</cstring>
               </property>
              </widget>
             </item>
@@ -551,6 +608,9 @@ QGroupBox {
               <property name="indent">
                <number>0</number>
               </property>
+              <property name="buddy">
+               <cstring>txtUserCommand0</cstring>
+              </property>
              </widget>
             </item>
             <item>
@@ -573,6 +633,9 @@ QGroupBox {
               </property>
               <property name="indent">
                <number>0</number>
+              </property>
+              <property name="buddy">
+               <cstring>txtUserCommand1</cstring>
               </property>
              </widget>
             </item>
@@ -597,6 +660,9 @@ QGroupBox {
               <property name="indent">
                <number>0</number>
               </property>
+              <property name="buddy">
+               <cstring>txtUserCommand2</cstring>
+              </property>
              </widget>
             </item>
             <item>
@@ -619,6 +685,9 @@ QGroupBox {
               </property>
               <property name="indent">
                <number>0</number>
+              </property>
+              <property name="buddy">
+               <cstring>txtUserCommand3</cstring>
               </property>
              </widget>
             </item>
@@ -647,6 +716,9 @@ QGroupBox {
                <widget class="QLabel" name="label_38">
                 <property name="text">
                  <string>Heightmap probing feed:</string>
+                </property>
+                <property name="buddy">
+                 <cstring>txtHeightMapProbingFeed</cstring>
                 </property>
                </widget>
               </item>
@@ -826,6 +898,9 @@ QGroupBox {
                   <property name="text">
                    <string>Line width:</string>
                   </property>
+                  <property name="buddy">
+                   <cstring>txtLineWidth</cstring>
+                  </property>
                  </widget>
                 </item>
                 <item>
@@ -852,6 +927,9 @@ QGroupBox {
                  <widget class="QLabel" name="label_7">
                   <property name="text">
                    <string>FPS lock:</string>
+                  </property>
+                  <property name="buddy">
+                   <cstring>cboFps</cstring>
                   </property>
                  </widget>
                 </item>
@@ -1027,12 +1105,18 @@ QGroupBox {
               <property name="text">
                <string>Type:</string>
               </property>
+              <property name="buddy">
+               <cstring>cboToolType</cstring>
+              </property>
              </widget>
             </item>
             <item row="1" column="0">
              <widget class="QLabel" name="label_4">
               <property name="text">
                <string>Diameter:</string>
+              </property>
+              <property name="buddy">
+               <cstring>txtToolDiameter</cstring>
               </property>
              </widget>
             </item>
@@ -1064,12 +1148,18 @@ QGroupBox {
               <property name="text">
                <string>Angle:</string>
               </property>
+              <property name="buddy">
+               <cstring>txtToolAngle</cstring>
+              </property>
              </widget>
             </item>
             <item row="1" column="4">
              <widget class="QLabel" name="lblToolLength">
               <property name="text">
                <string>Length:</string>
+              </property>
+              <property name="buddy">
+               <cstring>txtToolLength</cstring>
               </property>
              </widget>
             </item>
@@ -1378,6 +1468,9 @@ QGroupBox {
              <widget class="QLabel" name="label_29">
               <property name="text">
                <string>Size:</string>
+              </property>
+              <property name="buddy">
+               <cstring>cboFontSize</cstring>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Make a simple series of change to support connecting to gRBL remotely in addition to local serial (essentially just proxying over a tcp socket). This allows one to use a simple proxy box (like a Raspberry Pi setup with something like ser2net) and avoid having to keep your CNC connected to the main machine.

I had to make some other changes to the project file to be able to compile successfully but I can pull them out if desired.

I added a text input in the settings pane to be able to specify the host:port combo:

![image](https://user-images.githubusercontent.com/104105/145329689-b1079775-6ce8-4068-8b98-1b3cbd6468f2.png)

I have been using this functionality myself for the past few months without issues with a Raspberry Pi 3 and ser2net setup with this configuration:

```
6778:raw:6000:/dev/ttyUSB0:115200 8DATABITS NONE 1STOPBIT
```