### PR TITLE
Fix unused-{parameter,variable} warnings

### DIFF
--- a/src/frmmain.cpp
+++ b/src/frmmain.cpp
@@ -141,7 +141,7 @@ frmMain::frmMain(QWidget *parent) :
     connect(ui->cboCommand, SIGNAL(returnPressed()), this, SLOT(onCboCommandReturnPressed()));
 
     foreach (StyledToolButton* button, this->findChildren<StyledToolButton*>(QRegExp("cmdUser\\d"))) {
-        connect(button, SIGNAL(clicked(bool)), this, SLOT(onCmdUserClicked(bool)));
+        connect(button, SIGNAL(clicked(bool)), this, SLOT(onCmdUserClicked()));
     }
 
     // Setting up slider boxes
@@ -151,7 +151,7 @@ frmMain::frmMain(QWidget *parent) :
     ui->slbFeedOverride->setCurrentValue(100);
     ui->slbFeedOverride->setTitle(tr("Feed rate:"));
     ui->slbFeedOverride->setSuffix("%");
-    connect(ui->slbFeedOverride, SIGNAL(toggled(bool)), this, SLOT(onOverridingToggled(bool)));
+    connect(ui->slbFeedOverride, SIGNAL(toggled(bool)), this, SLOT(onOverridingToggled()));
     connect(ui->slbFeedOverride, &SliderBox::toggled, [=] {
         updateProgramEstimatedTime(m_currentDrawer->viewParser()->getLineSegmentList());
     });
@@ -165,7 +165,7 @@ frmMain::frmMain(QWidget *parent) :
     ui->slbRapidOverride->setCurrentValue(100);
     ui->slbRapidOverride->setTitle(tr("Rapid speed:"));
     ui->slbRapidOverride->setSuffix("%");
-    connect(ui->slbRapidOverride, SIGNAL(toggled(bool)), this, SLOT(onOverridingToggled(bool)));
+    connect(ui->slbRapidOverride, SIGNAL(toggled(bool)), this, SLOT(onOverridingToggled()));
     connect(ui->slbRapidOverride, &SliderBox::toggled, [=] {
         updateProgramEstimatedTime(m_currentDrawer->viewParser()->getLineSegmentList());
     });
@@ -179,7 +179,7 @@ frmMain::frmMain(QWidget *parent) :
     ui->slbSpindleOverride->setCurrentValue(100);
     ui->slbSpindleOverride->setTitle(tr("Spindle speed:"));
     ui->slbSpindleOverride->setSuffix("%");
-    connect(ui->slbSpindleOverride, SIGNAL(toggled(bool)), this, SLOT(onOverridingToggled(bool)));
+    connect(ui->slbSpindleOverride, SIGNAL(toggled(bool)), this, SLOT(onOverridingToggled()));
 
     m_originDrawer = new OriginDrawer();
     m_codeDrawer = new GcodeDrawer();
@@ -3834,7 +3834,7 @@ bool frmMain::compareCoordinates(double x, double y, double z)
     return ui->txtMPosX->text().toDouble() == x && ui->txtMPosY->text().toDouble() == y && ui->txtMPosZ->text().toDouble() == z;
 }
 
-void frmMain::onCmdUserClicked(bool checked)
+void frmMain::onCmdUserClicked()
 {
     int i = sender()->objectName().right(1).toInt();
 
@@ -3845,7 +3845,7 @@ void frmMain::onCmdUserClicked(bool checked)
     }
 }
 
-void frmMain::onOverridingToggled(bool checked)
+void frmMain::onOverridingToggled()
 {
     ui->grpOverriding->setProperty("overrided", ui->slbFeedOverride->isChecked()
                                    || ui->slbRapidOverride->isChecked() || ui->slbSpindleOverride->isChecked());

--- a/src/frmmain.h
+++ b/src/frmmain.h
@@ -103,8 +103,8 @@ private slots:
     void onTableCurrentChanged(QModelIndex idx1, QModelIndex idx2);
     void onConsoleResized(QSize size);
     void onPanelsSizeChanged(QSize size);
-    void onCmdUserClicked(bool checked);
-    void onOverridingToggled(bool checked);
+    void onCmdUserClicked();
+    void onOverridingToggled();
     void onActSendFromLineTriggered();
 
     void on_actFileExit_triggered();

--- a/src/parser/gcodeparser.cpp
+++ b/src/parser/gcodeparser.cpp
@@ -319,7 +319,7 @@ PointSegment *GcodeParser::addArcPointSegment(const QVector3D &nextPoint, bool c
     return ps;
 }
 
-void GcodeParser::handleMCode(float code, const QStringList &args)
+void GcodeParser::handleMCode(const QStringList &args)
 {
     double spindleSpeed = GcodePreprocessorUtils::parseCoord(args, 'S');
     if (!qIsNaN(spindleSpeed)) this->m_lastSpindleSpeed = spindleSpeed;

--- a/src/parser/gcodeparser.h
+++ b/src/parser/gcodeparser.h
@@ -78,7 +78,7 @@ private:
     QList<PointSegment*> m_points;
 
     PointSegment *processCommand(const QStringList &args);
-    void handleMCode(float code, const QStringList &args);
+    void handleMCode(const QStringList &args);
     PointSegment *handleGCode(float code, const QStringList &args);
     PointSegment *addLinearPointSegment(const QVector3D &nextPoint, bool fastTraverse);
     PointSegment *addArcPointSegment(const QVector3D &nextPoint, bool clockwise, const QStringList &args);

--- a/src/parser/gcodeviewparse.cpp
+++ b/src/parser/gcodeviewparse.cpp
@@ -101,7 +101,6 @@ QList<LineSegment*> GcodeViewParse::getLinesFromParser(GcodeParser *gp, double a
     QList<PointSegment*> psl = gp->getPointSegmentList();
     // For a line segment list ALL arcs must be converted to lines.
     double minArcLength = 0.1;
-    double length;
 
     QVector3D *start, *end;
     start = NULL;


### PR DESCRIPTION
A little bit of cleanup, extending the work done in #483 