### PR TITLE
A few minor changes from debian packaging fun

### DIFF
--- a/src/frmmain.cpp
+++ b/src/frmmain.cpp
@@ -85,7 +85,8 @@ frmMain::frmMain(QWidget *parent) :
                        << "black";
 
     // Loading settings
-    m_settingsFileName = qApp->applicationDirPath() + "/settings.ini";
+    m_settingsOrg = "Candle";
+    m_settingsApp = "candle";
     preloadSettings();
 
     m_settings = new frmSettings(this);
@@ -315,7 +316,7 @@ double frmMain::toolZPosition()
 
 void frmMain::preloadSettings()
 {
-    QSettings set(m_settingsFileName, QSettings::IniFormat);
+    QSettings set(m_settingsOrg, m_settingsApp);
     set.setIniCodec("UTF-8");
 
     qApp->setStyleSheet(QString(qApp->styleSheet()).replace(QRegExp("font-size:\\s*\\d+"), "font-size: " + set.value("fontSize", "8").toString()));
@@ -328,7 +329,7 @@ void frmMain::preloadSettings()
 
 void frmMain::loadSettings()
 {
-    QSettings set(m_settingsFileName, QSettings::IniFormat);
+    QSettings set(m_settingsOrg, m_settingsApp);
     set.setIniCodec("UTF-8");
 
     m_settingsLoading = true;
@@ -482,7 +483,7 @@ void frmMain::loadSettings()
 
 void frmMain::saveSettings()
 {
-    QSettings set(m_settingsFileName, QSettings::IniFormat);
+    QSettings set(m_settingsOrg, m_settingsApp);
     set.setIniCodec("UTF-8");
 
     set.setValue("port", m_settings->port());

--- a/src/frmmain.cpp
+++ b/src/frmmain.cpp
@@ -479,6 +479,13 @@ void frmMain::loadSettings()
     ui->cboCommand->setCurrentIndex(-1);
 
     m_settingsLoading = false;
+
+    if (!set.value("valid", false).toBool()) {
+	m_settings->setDefaults();
+	applySettings();
+	show();
+	ui->scrollArea->updateMinimumWidth();
+    }
 }
 
 void frmMain::saveSettings()
@@ -593,6 +600,7 @@ void frmMain::saveSettings()
 
     for (int i = 0; i < ui->cboCommand->count(); i++) list.append(ui->cboCommand->itemText(i));
     set.setValue("recentCommands", list);
+    set.setValue("valid", true);
 }
 
 bool frmMain::saveChanges(bool heightMapMode)

--- a/src/frmmain.cpp
+++ b/src/frmmain.cpp
@@ -282,7 +282,7 @@ frmMain::frmMain(QWidget *parent) :
     m_timerStateQuery.start();
 
     // Handle file drop
-    if (qApp->arguments().count() > 1 && isGCodeFile(qApp->arguments().last())) {
+    if (qApp->arguments().count() > 1) {
         loadFile(qApp->arguments().last());
     }
 }

--- a/src/frmmain.h
+++ b/src/frmmain.h
@@ -236,7 +236,8 @@ private:
     frmSettings *m_settings;
     frmAbout m_frmAbout;
 
-    QString m_settingsFileName;
+    QString m_settingsOrg;
+    QString m_settingsApp;
     QString m_programFileName;
     QString m_heightMapFileName;
     QString m_lastFolder;

--- a/src/frmsettings.cpp
+++ b/src/frmsettings.cpp
@@ -621,11 +621,8 @@ void frmSettings::on_cboToolType_currentIndexChanged(int index)
     ui->txtToolAngle->setEnabled(index == 1);
 }
 
-void frmSettings::on_cmdDefaults_clicked()
+void frmSettings::setDefaults()
 {
-    if (QMessageBox::warning(this, qApp->applicationDisplayName(), tr("Reset settings to default values?"),
-                             QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel) != QMessageBox::Yes) return;
-
     setPort("");
     setBaud(115200);
 
@@ -686,6 +683,14 @@ void frmSettings::on_cmdDefaults_clicked()
     ui->clpToolpathEnd->setColor(QColor(0, 255, 0));
 
     setFontSize(9);
+}
+
+void frmSettings::on_cmdDefaults_clicked()
+{
+    if (QMessageBox::warning(this, qApp->applicationDisplayName(), tr("Reset settings to default values?"),
+                             QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel) != QMessageBox::Yes) return;
+
+    setDefaults();
 }
 
 void frmSettings::on_cboFontSize_currentTextChanged(const QString &arg1)

--- a/src/frmsettings.h
+++ b/src/frmsettings.h
@@ -117,6 +117,7 @@ public:
     void setIgnoreErrors(bool value);
     bool autoLine();
     void setAutoLine(bool value);
+    void setDefaults();
 
 protected:
     void showEvent(QShowEvent *se);


### PR DESCRIPTION
I'm packaging this for debian and have a few minor changes that I've made:

 1. Use QSettings(org, app) instead of QSettings(filename). This lets Qt pick how to store settings, rather than storing them in the same directory as the application binary (which doesn't work on a multi-user system).
 2. Use default settings if none were stored. I just used the code in frmsettings.cpp.
 3. Allow any filename on the command line. My gcode files have a lot of random extensions.

Thanks for a really useful app; I'm no longer dependent on a Windows VM to drive my laser and router.