### PR TITLE
Cursor on XY plane feature, go to cursor on double click

### DIFF
--- a/src/candle/drawers/cursordrawer.cpp
+++ b/src/candle/drawers/cursordrawer.cpp
@@ -1,0 +1,148 @@
+// This file is a part of "G-Pilot (formerly Candle)" application.
+// Copyright 2015-2021 Hayrullin Denis Ravilevich
+// Copyright 2025 BTS
+
+#include "cursordrawer.h"
+
+void CursorDrawer::startAnimator()
+{
+    m_animator = new QPropertyAnimation(this, "animation");
+    m_animator->setDuration(500);
+    m_animator->setStartValue(0);
+    m_animator->setEndValue(3);
+    m_animator->setEasingCurve(QEasingCurve::InOutSine);
+    QObject::connect(m_animator, &QPropertyAnimation::finished, [this]() {
+        if (m_animator->direction() == QAbstractAnimation::Forward)
+            m_animator->setDirection(QAbstractAnimation::Backward);
+        else
+            m_animator->setDirection(QAbstractAnimation::Forward);
+        m_animator->start();
+    });
+    m_animator->start();
+}
+
+CursorDrawer::CursorDrawer() {
+    m_toolDiameter = 3;
+    m_toolLength = 15;
+    m_endLength = 10;
+    m_position = QVector3D(0, 0, 0);
+
+    startAnimator();
+}
+
+void CursorDrawer::setPosition(QPointF position)
+{
+    QVector3D pos3d(position.x(), position.y(), 0);
+    if (m_position != pos3d) {
+        m_position = pos3d;
+        update();
+    }
+}
+
+void CursorDrawer::setVisible(bool visible) {
+    m_visible = visible;
+    update();
+}
+
+bool CursorDrawer::updateData()
+{
+    const int arcs = 4;
+    const float z = m_position.z() + m_animation;
+
+    // Clear data
+    m_lines.clear();
+    m_points.clear();
+
+    // Prepare vertex
+    VertexData vertex;
+    vertex.type = VertexDataTypeLine;
+    vertex.color = Util::colorToVector(m_color);//QVector3D(1.0, 0.6, 0.0);
+
+    // Draw circles
+    // Bottom
+    m_lines += createCircle(QVector3D(m_position.x(), m_position.y(), z + m_endLength),
+                            m_toolDiameter / 2, 20, vertex.color);
+
+    // Top
+    m_lines += createCircle(QVector3D(m_position.x(), m_position.y(), z + m_toolLength),
+                            m_toolDiameter / 2, 20, vertex.color);
+
+    // Zero Z circle
+    if (m_endLength == 0) {
+        m_lines += createCircle(QVector3D(m_position.x(), m_position.y(), 0),
+                                m_toolDiameter / 2, 20, vertex.color);
+    }
+
+    // Draw lines
+    for (int i = 0; i < arcs; i++) {
+        double x = m_position.x() + m_toolDiameter / 2 * cos((2 * M_PI / arcs) * i);
+        double y = m_position.y() + m_toolDiameter / 2 * sin((2 * M_PI / arcs) * i);
+
+        // Side lines
+        vertex.position = QVector3D(x, y, z + m_endLength);
+        m_lines.append(vertex);
+        vertex.position = QVector3D(x, y, z + m_toolLength);
+        m_lines.append(vertex);
+
+        // Bottom lines
+        vertex.position = QVector3D(m_position.x(), m_position.y(), z);
+        m_lines.append(vertex);
+        vertex.position = QVector3D(x, y, z + m_endLength);
+        m_lines.append(vertex);
+
+        // Top lines
+        vertex.position = QVector3D(m_position.x(), m_position.y(), z + m_toolLength);
+        m_lines.append(vertex);
+        vertex.position = QVector3D(x, y, z + m_toolLength);
+        m_lines.append(vertex);
+    }
+
+    for (int i = 0; i < arcs; i++) {
+        // Zero Z lines
+        double x = m_position.x() + m_toolDiameter / 2 * cos((2 * M_PI / arcs) * i);
+        double y = m_position.y() + m_toolDiameter / 2 * sin((2 * M_PI / arcs) * i);
+
+        vertex.position = QVector3D(m_position.x(), m_position.y(), 0);
+        m_lines.append(vertex);
+        vertex.position = QVector3D(x, y, 0);
+        m_lines.append(vertex);
+    }
+
+    return true;
+}
+
+QVector<VertexData> CursorDrawer::createCircle(QVector3D center, double radius, int arcs, QVector3D color)
+{
+    // Vertices
+    QVector<VertexData> circle;
+
+    // Prepare vertex
+    VertexData vertex;
+    vertex.type = VertexDataTypeLine;
+    vertex.color = color;
+
+    // Create line loop
+    for (int i = 0; i <= arcs; i++) {
+        double angle = 2 * M_PI * i / arcs;
+        double x = center.x() + radius * cos(angle);
+        double y = center.y() + radius * sin(angle);
+
+        if (i > 1) {
+            circle.append(circle.last());
+        }
+        else if (i == arcs) circle.append(circle.first());
+
+        vertex.position = QVector3D(x, y, center.z());
+        circle.append(vertex);
+    }
+
+    return circle;
+}
+
+void CursorDrawer::setAnimation(float value)
+{
+    m_animation = value;
+    if (m_visible) {
+        update();
+    }
+}

--- a/src/candle/drawers/cursordrawer.h
+++ b/src/candle/drawers/cursordrawer.h
@@ -1,0 +1,43 @@
+// This file is a part of "G-Pilot (formerly Candle)" application.
+// Copyright 2015-2021 Hayrullin Denis Ravilevich
+// Copyright 2025 BTS
+
+#ifndef CURSORDRAWER_H
+#define CURSORDRAWER_H
+
+#include <QPropertyAnimation>
+#include "shaderdrawable.h"
+
+class CursorDrawer : public QObject, public ShaderDrawable
+{
+    Q_OBJECT
+    Q_PROPERTY(float animation WRITE setAnimation)
+
+public:
+    explicit CursorDrawer();
+
+    void setPosition(QPointF position);
+    void setVisible(bool visible);
+
+protected:
+    bool updateData();
+    double m_toolDiameter;
+    double m_toolLength;
+    double m_endLength;
+    QVector3D m_position;
+    double m_tipAngle;
+    QColor m_color;
+    float m_animation;
+
+    double normalizeAngle(double angle);
+    QVector<VertexData> createCircle(QVector3D center, double radius, int arcs, QVector3D color);
+
+
+private:
+    QPropertyAnimation *m_animator;
+
+    void startAnimator();
+    void setAnimation(float value);
+};
+
+#endif // CURSORDRAWER_H

--- a/src/candle/frmmain.h
+++ b/src/candle/frmmain.h
@@ -24,6 +24,7 @@
 #include "drawers/origindrawer.h"
 #include "drawers/gcodedrawer.h"
 #include "drawers/tooldrawer.h"
+#include "drawers/cursordrawer.h"
 #include "drawers/heightmapborderdrawer.h"
 #include "drawers/heightmapgriddrawer.h"
 #include "drawers/heightmapinterpolationdrawer.h"
@@ -349,6 +350,7 @@ private:
     GcodeDrawer *m_probeDrawer;
     GcodeDrawer *m_currentDrawer;
     ToolDrawer m_toolDrawer;
+    CursorDrawer m_cursorDrawer;
     HeightMapBorderDrawer m_heightMapBorderDrawer;
     OriginDrawer m_heightMapOriginDrawer;
     HeightMapGridDrawer m_heightMapGridDrawer;

--- a/src/candle/widgets/glwidget.h
+++ b/src/candle/widgets/glwidget.h
@@ -22,6 +22,7 @@ public:
     void fitDrawable(ShaderDrawable *drawable = NULL);
     bool antialiasing() const;
     void setAntialiasing(bool antialiasing);
+    QPointF calcPositionOnXYPlane(QPoint pos);
 
     QTime spendTime() const;
     void setSpendTime(const QTime &spendTime);
@@ -81,6 +82,10 @@ public:
 signals:
     void rotationChanged();
     void resized();
+    void cursorPosChanged(QPointF);
+    void goToCursor(QPointF);
+    void entered();
+    void left();
 
 public slots:
 
@@ -93,6 +98,7 @@ private:
     QPointF m_storedRot;
     QPointF m_pan;
     QPointF m_storedPan;
+    QPointF m_cursorPos;
 
     QVector3D m_lookAt;
 
@@ -161,7 +167,10 @@ protected:
     void paintGL() override;
     bool event(QEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
+    void enterEvent(QEvent *event) override;
+    void leaveEvent(QEvent *event) override;
     void wheelEvent(QWheelEvent *we) override;
     void timerEvent(QTimerEvent *) override;
 

--- a/src/candle/widgets/overlay.cpp
+++ b/src/candle/widgets/overlay.cpp
@@ -13,6 +13,10 @@ void Overlay::paintEvent(QPaintEvent *pe)
     QPainter painter(this);
     QFontMetrics fm(painter.font());
 
+    auto cursor = QString("Cursor: ?, ?");
+    if (!qIsNaN(m_parent->m_cursorPos.x())) {
+        cursor = QString("Cursor: %1, %2").arg(m_parent->m_cursorPos.x(), 0, 'f', 3).arg(m_parent->m_cursorPos.y(), 0, 'f', 3);
+    }
     auto xbounds = QString("X: %1 ... %2").arg(m_parent->m_modelLowerBounds.x(), 0, 'f', 3)
         .arg(m_parent->m_modelUpperBounds.x(), 0, 'f', 3);
     auto ybounds = QString("Y: %1 ... %2").arg(m_parent->m_modelLowerBounds.y(), 0, 'f', 3)
@@ -27,7 +31,7 @@ void Overlay::paintEvent(QPaintEvent *pe)
     auto buffer = m_parent->m_bufferState;
 
     double x = 10;
-    double y = this->height() - fm.height() * 3 - 10;
+    double y = this->height() - fm.height() * 4 - 10;
 
     // painter.setBrush(QBrush(QColor(255, 255, 255, 196)));
     // painter.drawRect(5, 5, fm.horizontalAdvance(m_parent->m_parserStatus) + 10, fm.height() * 3 + 10);
@@ -47,6 +51,7 @@ void Overlay::paintEvent(QPaintEvent *pe)
     painter.drawText(QPoint(x, y + fm.height()), ybounds);
     painter.drawText(QPoint(x, y + fm.height() * 2), zbounds);
     painter.drawText(QPoint(x, y + fm.height() * 3), ranges);
+    painter.drawText(QPoint(x, y + fm.height() * 4), cursor);
 
     painter.drawText(QPoint(x, fm.height() + 10), m_parent->m_parserStatus);
     painter.drawText(QPoint(x, fm.height() * 2 + 10), m_parent->m_speedState);


### PR DESCRIPTION
Hello. This feature adds a cursor to the G-code visualizer that shows the position on the 2D plane. The current X, Y position is displayed in the bottom-left corner. By double-clicking on the visualizer, you can move the tool to the selected position. This can be dangerous (a crash may happen), so a warning and confirmation message appear before moving. I created this because i often needed to move the tool to a specific place to check if the material size is correct or if the tool might hit clamps. Using only jogging was quite inconvenient. 

This is a draft/mvp. More checks may be needed, such as verifying if the machine is idle or if the position is inside the work area.

Feedback is welcome.

<img width="673" height="507" alt="image" src="https://github.com/user-attachments/assets/ab225d66-9c4a-417c-8edf-b5639c98e2e6" />
<img width="609" height="230" alt="image" src="https://github.com/user-attachments/assets/5ce26430-3021-4aea-8a8a-7a827a1fbf95" />
