### PR TITLE
Add G2/G3 P-code support for multi-turn helical arcs

### DIFF
--- a/src/candle/parser/arcproperties.cpp
+++ b/src/candle/parser/arcproperties.cpp
@@ -11,4 +11,5 @@ ArcProperties::ArcProperties()
 {
     radius = 0;
     center = NULL;
+    turns = 1;
 }

--- a/src/candle/parser/arcproperties.h
+++ b/src/candle/parser/arcproperties.h
@@ -17,6 +17,7 @@ public:
     bool isClockwise;
     double radius;
     QVector3D *center;
+    int turns;
 };
 
 #endif // ARCPROPERTIES_H

--- a/src/candle/parser/gcodepreprocessorutils.cpp
+++ b/src/candle/parser/gcodepreprocessorutils.cpp
@@ -425,7 +425,7 @@ double GcodePreprocessorUtils::getAngle(QVector3D start, QVector3D end) {
     return angle;
 }
 
-double GcodePreprocessorUtils::calculateSweep(double startAngle, double endAngle, bool isCw)
+double GcodePreprocessorUtils::calculateSweep(double startAngle, double endAngle, bool isCw, int turns)
 {
     double sweep;
 
@@ -448,13 +448,18 @@ double GcodePreprocessorUtils::calculateSweep(double startAngle, double endAngle
         }
     }
 
+    // Add extra full circles for P > 1
+    if (turns > 1) {
+        sweep += (M_PI * 2) * (turns - 1);
+    }
+
     return sweep;
 }
 
 /**
 * Generates the points along an arc including the start and end points.
 */
-QList<QVector3D> GcodePreprocessorUtils::generatePointsAlongArcBDring(PointSegment::planes plane, QVector3D start, QVector3D end, QVector3D center, bool clockwise, double R, double minArcLength, double arcPrecision, bool arcDegreeMode)
+QList<QVector3D> GcodePreprocessorUtils::generatePointsAlongArcBDring(PointSegment::planes plane, QVector3D start, QVector3D end, QVector3D center, bool clockwise, double R, double minArcLength, double arcPrecision, bool arcDegreeMode, int turns)
 {
     double radius = R;
 
@@ -485,7 +490,7 @@ QList<QVector3D> GcodePreprocessorUtils::generatePointsAlongArcBDring(PointSegme
 
     double startAngle = getAngle(center, start);
     double endAngle = getAngle(center, end);
-    double sweep = calculateSweep(startAngle, endAngle, clockwise);
+    double sweep = calculateSweep(startAngle, endAngle, clockwise, turns);
 
     // Convert units.
     double arcLength = sweep * radius;

--- a/src/candle/parser/gcodepreprocessorutils.h
+++ b/src/candle/parser/gcodepreprocessorutils.h
@@ -35,8 +35,8 @@ public:
     static QVector3D updateCenterWithCommand(QStringList commandArgs, QVector3D initial, QVector3D nextPoint, bool absoluteIJKMode, bool clockwise);
     static QString generateG1FromPoints(QVector3D start, QVector3D end, bool absoluteMode, int precision);
     static double getAngle(QVector3D start, QVector3D end);
-    static double calculateSweep(double startAngle, double endAngle, bool isCw);
-    static QList<QVector3D> generatePointsAlongArcBDring(PointSegment::planes plane, QVector3D start, QVector3D end, QVector3D center, bool clockwise, double R, double minArcLength, double arcPrecision, bool arcDegreeMode);
+    static double calculateSweep(double startAngle, double endAngle, bool isCw, int turns = 1);
+    static QList<QVector3D> generatePointsAlongArcBDring(PointSegment::planes plane, QVector3D start, QVector3D end, QVector3D center, bool clockwise, double R, double minArcLength, double arcPrecision, bool arcDegreeMode, int turns = 1);
     static QList<QVector3D> generatePointsAlongArcBDring(PointSegment::planes plane, QVector3D p1, QVector3D p2, QVector3D center, bool isCw, double radius, double startAngle, double sweep, int numPoints);
     static inline bool isDigit(char c);
     static inline bool isLetter(char c);

--- a/src/candle/parser/gcodeviewparse.cpp
+++ b/src/candle/parser/gcodeviewparse.cpp
@@ -180,9 +180,9 @@ QList<LineSegment*> GcodeViewParse::getLinesFromParser(GcodeParser *gp, double a
             if (ps->isArc()) {
                 QList<QVector3D> points =
                     GcodePreprocessorUtils::generatePointsAlongArcBDring(
-                        ps->plane(), *start, *end, 
-                        *ps->center(), ps->isClockwise(), ps->getRadius(), 
-                        minArcLength, arcPrecision, arcDegreeMode);
+                        ps->plane(), *start, *end,
+                        *ps->center(), ps->isClockwise(), ps->getRadius(),
+                        minArcLength, arcPrecision, arcDegreeMode, ps->getArcTurns());
 
                 // Create line segments from points.
                 int segments = points.length();

--- a/src/candle/parser/pointsegment.cpp
+++ b/src/candle/parser/pointsegment.cpp
@@ -256,3 +256,15 @@ void PointSegment::setDwell(double dwell)
 {
     m_dwell = dwell;
 }
+
+int PointSegment::getArcTurns() const
+{
+    if (this->m_arcProperties != NULL) return this->m_arcProperties->turns;
+    return 1;
+}
+
+void PointSegment::setArcTurns(int turns)
+{
+    if (this->m_arcProperties == NULL) this->m_arcProperties = new ArcProperties();
+    this->m_arcProperties->turns = turns > 0 ? turns : 1;
+}

--- a/src/candle/parser/pointsegment.h
+++ b/src/candle/parser/pointsegment.h
@@ -67,6 +67,9 @@ public:
     double getDwell() const;
     void setDwell(double dwell);
 
+    int getArcTurns() const;
+    void setArcTurns(int turns);
+
 private:
     ArcProperties *m_arcProperties;
     int m_toolhead;


### PR DESCRIPTION
Implement LinuxCNC-compatible P parameter for G2/G3 arc commands, enabling multi-turn helical interpolation for thread milling and deep hole machining operations.

Changes:
- Add turns field to ArcProperties class (default: 1)
- Add getArcTurns/setArcTurns methods to PointSegment
- Parse P parameter in addArcPointSegment for G2/G3 commands
- Update calculateSweep to multiply sweep angle by turns count
- Update generatePointsAlongArcBDring to accept turns parameter
- Pass turns parameter through all arc generation call sites

Technical details:
- P1 (default): Single turn (backward compatible)
- P2: Base arc + 1 full circle (360°)
- P3: Base arc + 2 full circles (720°)
- Sweep calculation: sweep += (2π × (turns - 1))

Test case: "G2 Z-10 I0 J-10 P2" now produces 2 complete turns as per LinuxCNC specification. ---
 src/candle/parser/arcproperties.cpp          |  1 +
 src/candle/parser/arcproperties.h            |  1 +
 src/candle/parser/gcodeparser.cpp            | 10 ++++------
 src/candle/parser/gcodepreprocessorutils.cpp | 11 ++++++++---
 src/candle/parser/gcodepreprocessorutils.h   |  4 ++--
 src/candle/parser/gcodeviewparse.cpp         |  6 +++---
 src/candle/parser/pointsegment.cpp           | 12 ++++++++++++
 src/candle/parser/pointsegment.h             |  3 +++
 8 files changed, 34 insertions(+), 14 deletions(-)
Assisted by intelligence

ref: https://github.com/Denvi/Candle/issues/562