### PR TITLE
qt5.x: remove some deprecated apis use

### DIFF
--- a/src/candle/frmabout.cpp
+++ b/src/candle/frmabout.cpp
@@ -2,6 +2,7 @@
 // Copyright 2015-2021 Hayrullin Denis Ravilevich
 
 #include <QDesktopServices>
+#include <QFile>
 #include "frmabout.h"
 #include "ui_frmabout.h"
 #include "versionconfig.h"

--- a/src/candle/frmmain.cpp
+++ b/src/candle/frmmain.cpp
@@ -181,7 +181,7 @@ frmMain::frmMain(QWidget *parent) :
 
     connect(ui->cboCommand, SIGNAL(returnPressed()), this, SLOT(onCboCommandReturnPressed()));
 
-    foreach (StyledToolButton* button, this->findChildren<StyledToolButton*>(QRegExp("cmdUser\\d"))) {
+    foreach (StyledToolButton* button, this->findChildren<StyledToolButton*>(QRegularExpression("cmdUser\\d"))) {
         connect(button, SIGNAL(clicked(bool)), this, SLOT(onCmdUserClicked(bool)));
     }
 
@@ -302,7 +302,7 @@ frmMain::frmMain(QWidget *parent) :
     updateControlsState();
 
     // Prepare jog buttons
-    foreach (StyledToolButton* button, ui->grpJog->findChildren<StyledToolButton*>(QRegExp("cmdJogFeed\\d")))
+    foreach (StyledToolButton* button, ui->grpJog->findChildren<StyledToolButton*>(QRegularExpression("cmdJogFeed\\d")))
     {
         connect(button, SIGNAL(clicked(bool)), this, SLOT(onCmdJogFeedClicked()));
     }
@@ -587,7 +587,7 @@ void frmMain::on_actFileExit_triggered()
 
 void frmMain::on_actServiceSettings_triggered()
 {
-    m_settings->setShortcuts(findChildren<QAction*>(QRegExp("act.*")));
+    m_settings->setShortcuts(findChildren<QAction*>(QRegularExpression("act.*")));
 
     emit settingsAboutToShow();
 
@@ -848,7 +848,7 @@ void frmMain::on_cmdFileOpen_clicked()
         QString fileName  = QFileDialog::getOpenFileName(this, tr("Open"), m_lastFolder,
                                    tr("G-Code files (*.nc *.ncc *.ngc *.tap *.txt *.gcode);;All files (*.*)"));
 
-        if (!fileName.isEmpty()) m_lastFolder = fileName.left(fileName.lastIndexOf(QRegExp("[/\\\\]+")));
+        if (!fileName.isEmpty()) m_lastFolder = fileName.left(fileName.lastIndexOf(QRegularExpression("[/\\\\]+")));
 
         if (fileName != "") {
             addRecentFile(fileName);
@@ -2329,7 +2329,7 @@ void frmMain::onConnectionDataReceived(QString data)
                 }
 
                 // Change state query time on check mode on
-                if (uncomment.contains(QRegExp("$[cC]"))) {
+                if (uncomment.contains(QRegularExpression("$[cC]"))) {
                     m_timerStateQuery.setInterval(response.contains("Enable") ? 1000 : m_settings->queryStateTime());
                 }
 
@@ -2425,7 +2425,7 @@ void frmMain::onConnectionDataReceived(QString data)
 
                     // Check transfer complete (last row always blank, last command row = rowcount - 2)
                     if ((m_fileProcessedCommandIndex == m_currentModel->rowCount() - 2) ||
-                        uncomment.contains(QRegExp("(M0*2|M30)(?!\\d)")))
+                        uncomment.contains(QRegularExpression("(M0*2|M30)(?!\\d)")))
                     {
                         if (m_deviceState == DeviceRun) {
                             setSenderState(SenderStopping);
@@ -3026,7 +3026,7 @@ void frmMain::preloadSettings()
     QSettings set;
     set.beginGroup("General");
 
-    qApp->setStyleSheet(QString(qApp->styleSheet()).replace(QRegExp("font-size:\\s*\\d+"), "font-size: "
+    qApp->setStyleSheet(QString(qApp->styleSheet()).replace(QRegularExpression("font-size:\\s*\\d+"), "font-size: "
         + set.value("fontSize", "9").toString()));
 
     set.endGroup();
@@ -3253,7 +3253,7 @@ void frmMain::storeSettings()
     ShortcutsMap m;
     QByteArray ba;
     QDataStream s(&ba, QIODevice::WriteOnly);
-    QList<QAction*> acts = findChildren<QAction*>(QRegExp("act.*"));
+    QList<QAction*> acts = findChildren<QAction*>(QRegularExpression("act.*"));
 
     foreach (QAction *a, acts) m[a->objectName()] = a->shortcuts();
     s << m;
@@ -3388,7 +3388,7 @@ void frmMain::restoreSettings()
             pick->setColor(QColor(set->value(pick->objectName().mid(3), "black").toString()));
         }
     } else {
-        m_settings->setShortcuts(findChildren<QAction*>(QRegExp("act.*")));
+        m_settings->setShortcuts(findChildren<QAction*>(QRegularExpression("act.*")));
         m_settings->setDefaultSettings();
     }
 
@@ -3614,7 +3614,7 @@ void frmMain::loadProfiles(QSettings &set)
 void frmMain::applySettings()
 {
     // Apply font size QWidget {font-size: 8pt}
-    qApp->setStyleSheet(QString(qApp->styleSheet()).replace(QRegExp(
+    qApp->setStyleSheet(QString(qApp->styleSheet()).replace(QRegularExpression(
         "QWidget \\{font-size: \\d+pt\\}"),
         QString("QWidget {font-size: %1pt}").arg(m_settings->fontSize()))
     );
@@ -3643,7 +3643,7 @@ void frmMain::applySettings()
     ui->dockUser->setMaximumWidth(panelWidth + ui->scrollArea->verticalScrollBar()->width());
 
     // Update shortcuts
-    QList<QAction*> acts = findChildren<QAction*>(QRegExp("act.*"));
+    QList<QAction*> acts = findChildren<QAction*>(QRegularExpression("act.*"));
     QTableWidget *shortcuts = m_settings->shortcuts();
 
     for (int i = 0; i < shortcuts->rowCount(); i++) {
@@ -4003,7 +4003,7 @@ void frmMain::loadPlugins()
                     layout1->addWidget(bw);
                     bw->setLayout(layout2);
                     layout2->addWidget(w);
-                    layout2->setMargin(0);
+                    layout2->setContentsMargins(0, 0, 0, 0);
                     connect(box, &QGroupBox::toggled, bw, &QWidget::setVisible);
 
                     // Add panel to user window
@@ -4036,7 +4036,7 @@ void frmMain::loadPlugins()
                     layout1->setContentsMargins(m);
                     frame->setLayout(layout2);
                     layout2->addWidget(w);
-                    layout2->setMargin(0);
+                    layout2->setContentsMargins(0, 0, 0, 0);
 
                     // Add to main form
                     this->addDockWidget(Qt::LeftDockWidgetArea, dock);
@@ -4287,7 +4287,7 @@ void frmMain::updateParser()
 void frmMain::storeParserState()
 {
     m_storedParserStatus = ui->glwVisualizer->parserStatus().remove(
-                QRegExp("GC:|\\[|\\]|G[01234]\\s|M[0345]+\\s|\\sF[\\d\\.]+|\\sS[\\d\\.]+"));
+                QRegularExpression("GC:|\\[|\\]|G[01234]\\s|M[0345]+\\s|\\sF[\\d\\.]+|\\sS[\\d\\.]+"));
 }
 
 void frmMain::restoreParserState()
@@ -5218,7 +5218,7 @@ bool frmMain::dataIsEnd(QString data) {
 }
 
 bool frmMain::dataIsReset(QString data) {
-    return QRegExp("^GRBL|GCARVIN\\s\\d\\.\\d.").indexIn(data.toUpper()) != -1;
+    return QRegularExpression("^GRBL|GCARVIN\\s\\d\\.\\d.").match(data.toUpper()).hasMatch();
 }
 
 void frmMain::updateProgramEstimatedTime(QList<LineSegment*> lines)

--- a/src/candle/frmmain.h
+++ b/src/candle/frmmain.h
@@ -389,7 +389,7 @@ private:
     QTimer m_timerConnection;
     QTimer m_timerStateQuery;
     QBasicTimer m_timerToolAnimation;
-    QTime m_startTime;
+    QElapsedTimer m_startTime;
 
     // Stored parser params
     QString m_storedParserStatus;

--- a/src/candle/frmsettings.cpp
+++ b/src/candle/frmsettings.cpp
@@ -345,7 +345,7 @@ void frmSettings::setLaserPowerMax(int value)
 
 QStringList frmSettings::jogSteps()
 {
-    return ui->txtJogSteps->text().split(QRegExp("\\s*,\\s*"));
+    return ui->txtJogSteps->text().split(QRegularExpression("\\s*,\\s*"));
 }
 
 void frmSettings::setJogSteps(QStringList steps)
@@ -355,7 +355,7 @@ void frmSettings::setJogSteps(QStringList steps)
 
 QStringList frmSettings::jogFeeds()
 {
-    return ui->txtJogFeeds->text().split(QRegExp("\\s*,\\s"));
+    return ui->txtJogFeeds->text().split(QRegularExpression("\\s*,\\s"));
 }
 
 void frmSettings::setJogFeeds(QStringList feeds)

--- a/src/candle/tables/gcodetablemodel.cpp
+++ b/src/candle/tables/gcodetablemodel.cpp
@@ -124,7 +124,7 @@ QVariant GCodeTableModel::headerData(int section, Qt::Orientation orientation, i
 
 Qt::ItemFlags GCodeTableModel::flags(const QModelIndex &index) const
 {
-    if (!index.isValid()) return NULL;
+    if (!index.isValid()) return Qt::NoItemFlags;
     if (index.column() == 1) return QAbstractTableModel::flags(index) | Qt::ItemIsEditable;
     else return QAbstractTableModel::flags(index);
 }

--- a/src/candle/tables/heightmaptablemodel.cpp
+++ b/src/candle/tables/heightmaptablemodel.cpp
@@ -98,7 +98,7 @@ QVariant HeightMapTableModel::headerData(int section, Qt::Orientation orientatio
 
 Qt::ItemFlags HeightMapTableModel::flags(const QModelIndex &index) const
 {
-    if (!index.isValid()) return NULL;
+    if (!index.isValid()) return Qt::NoItemFlags;
     return QAbstractTableModel::flags(index) | Qt::ItemIsEditable;
 }
 

--- a/src/candle/widgets/glwidget.cpp
+++ b/src/candle/widgets/glwidget.cpp
@@ -597,16 +597,16 @@ void GLWidget::mouseMoveEvent(QMouseEvent *event)
 void GLWidget::wheelEvent(QWheelEvent *we)
 {
     if (we->angleDelta().manhattanLength() >= 120) {
-        if (m_zoom > 0.1 && we->delta() < 0) {
-            m_pan.setX(m_pan.x() - ((double)we->pos().x() / width() - 0.5 + m_pan.x()) * (1 - 1 / ZOOMSTEP));
-            m_pan.setY(m_pan.y() + ((double)we->pos().y() / height() - 0.5 - m_pan.y()) * (1 - 1 / ZOOMSTEP));
+        if (m_zoom > 0.1 && we->angleDelta().y() < 0) {
+            m_pan.setX(m_pan.x() - ((double)we->position().x() / width() - 0.5 + m_pan.x()) * (1 - 1 / ZOOMSTEP));
+            m_pan.setY(m_pan.y() + ((double)we->position().y() / height() - 0.5 - m_pan.y()) * (1 - 1 / ZOOMSTEP));
 
             m_zoom /= ZOOMSTEP;
         }
-        else if (m_zoom < 10 && we->delta() > 0)
+        else if (m_zoom < 10 && we->angleDelta().y() > 0)
         {
-            m_pan.setX(m_pan.x() - ((double)we->pos().x() / width() - 0.5 + m_pan.x()) * (1 - ZOOMSTEP));
-            m_pan.setY(m_pan.y() + ((double)we->pos().y() / height() - 0.5 - m_pan.y()) * (1 - ZOOMSTEP));
+            m_pan.setX(m_pan.x() - ((double)we->position().x() / width() - 0.5 + m_pan.x()) * (1 - ZOOMSTEP));
+            m_pan.setY(m_pan.y() + ((double)we->position().y() / height() - 0.5 - m_pan.y()) * (1 - ZOOMSTEP));
 
             m_zoom *= ZOOMSTEP;
         }

--- a/src/candle/widgets/overlay.cpp
+++ b/src/candle/widgets/overlay.cpp
@@ -52,10 +52,10 @@ void Overlay::paintEvent(QPaintEvent *pe)
     painter.drawText(QPoint(x, fm.height() * 2 + 10), m_parent->m_speedState);
     painter.drawText(QPoint(x, fm.height() * 3 + 10), m_parent->m_pinState);
 
-    painter.drawText(QPoint(this->width() - fm.width(vertices) - 10, y + fm.height() * 2), vertices);
-    painter.drawText(QPoint(this->width() - fm.width(fps) - 10, y + fm.height() * 3), fps);
-    painter.drawText(QPoint(this->width() - fm.width(estimate) - 10, y), estimate);
-    painter.drawText(QPoint(this->width() - fm.width(buffer) - 10, y + fm.height()), buffer);
+    painter.drawText(QPoint(this->width() - fm.horizontalAdvance(vertices) - 10, y + fm.height() * 2), vertices);
+    painter.drawText(QPoint(this->width() - fm.horizontalAdvance(fps) - 10, y + fm.height() * 3), fps);
+    painter.drawText(QPoint(this->width() - fm.horizontalAdvance(estimate) - 10, y), estimate);
+    painter.drawText(QPoint(this->width() - fm.horizontalAdvance(buffer) - 10, y + fm.height()), buffer);
 
     QMatrix4x4 w;
     w.scale(width() / 2, -height() / 2);

--- a/src/customwidgets/styledtoolbutton.cpp
+++ b/src/customwidgets/styledtoolbutton.cpp
@@ -43,7 +43,6 @@ void StyledToolButton::paintEvent(QPaintEvent *e)
     QPainter painter(this);
 
     painter.setRenderHint(QPainter::Antialiasing);
-    painter.setRenderHint(QPainter::HighQualityAntialiasing);
 
     // Highlight
     QPen highlightPen;


### PR DESCRIPTION
This is upstream port of the PR I sent to the fork at https://github.com/Schildkroet/Candle2/pull/70

I do not intend to fully finish porting, but in case you want to support Qt6 in the future, these changes will probably make it less work.