### PR TITLE
feat: Enhance HeightMap with Corner Navigation and Trace Speed Control

### DIFF
--- a/src/candle/frmmain.cpp
+++ b/src/candle/frmmain.cpp
@@ -179,6 +179,9 @@ void frmMain::initUi()
     ui->fraDropModification->setVisible(false);
     ui->fraDropUser->setVisible(false);
 
+    // Default Speed Selection
+    ui->cboTraceSpeed->setCurrentIndex(1); // 0=Slow, 1=Medium, 2=Fast
+
     // Dock widgets
     setCorner(Qt::TopLeftCorner, Qt::LeftDockWidgetArea);
     setCorner(Qt::BottomLeftCorner, Qt::LeftDockWidgetArea);
@@ -3380,7 +3383,10 @@ void frmMain::saveSettings()
 
     // Language
     set.setValue("language", m_settings->language());
-
+	
+	// Save Trace Z
+    set.setValue("heightmapTraceZ", ui->txtHeightMapTraceZ->value());
+	
     set.endGroup();
 }
 
@@ -3570,7 +3576,10 @@ void frmMain::storeSettings()
 void frmMain::restoreSettings()
 {
     auto set = m_storage.group("General");
-
+	
+	// Restore Trace Z
+    ui->txtHeightMapTraceZ->setValue(set->value("heightmapTraceZ", 5.0).toDouble());
+	
     m_settingsLoading = true;
 
     emit settingsAboutToLoad();
@@ -5996,3 +6005,204 @@ QScriptValue frmMain::importExtension(QScriptContext *context, QScriptEngine *en
 {
     return engine->importExtension(context->argument(0).toString());
 }
+
+// =================================================================
+// Emergency Stop Button
+// =================================================================
+void frmMain::on_cmdHeightMapStop_clicked()
+{
+    // Send reset command to the controller. This command stops all movements immediately.
+    grblReset();
+}
+
+// =================================================================
+// Trace Border Function with Speed Control
+// =================================================================
+void frmMain::on_cmdHeightMapTrace_clicked()
+{
+    if (m_deviceState != DeviceIdle && m_deviceState != DeviceJog) {
+         QMessageBox::warning(this, tr("Safety Error"), tr("Device is busy. Please wait for IDLE state."));
+         return;
+    }
+
+    double x = ui->txtHeightMapBorderX->value();
+    double y = ui->txtHeightMapBorderY->value();
+    double w = ui->txtHeightMapBorderWidth->value();
+    double h = ui->txtHeightMapBorderHeight->value();
+
+    if (w <= 0 || h <= 0) return;
+
+    double safeZ = ui->txtHeightMapTraceZ->value();
+
+    // Determine speed based on user selection
+    // Recommended values (mm/min)
+    int speedIndex = ui->cboTraceSpeed->currentIndex();
+    double traceFeed;
+
+    switch (speedIndex) {
+        case 0: traceFeed = 300.0;  break; // Slow - for high precision
+        case 1: traceFeed = 800.0;  break; // Medium
+        case 2: traceFeed = 2000.0; break; // Fast - quick but risky
+        default: traceFeed = 500.0;
+    }
+
+    // Coordinate calculation
+    double x_start = x;
+    double y_start = y;
+    double x_end = x + w;
+    double y_end = y + h;
+
+    QStringList cmds;
+
+    // 1. Set Absolute mode (G90) and Millimeters (G21)
+    cmds << "G21 G90";
+
+    // 2. Move tool up to Safe Z at maximum speed (G0)
+    cmds << QString("G0 Z%1").arg(safeZ);
+
+    // 3. Move to starting point (bottom-left corner) at maximum speed
+    cmds << QString("G0 X%1 Y%2").arg(x_start).arg(y_start);
+
+    // 4. Trace the border with user-selected speed (G1 F...)
+    cmds << QString("G1 X%1 F%2").arg(x_end).arg(traceFeed); // Move Right
+    cmds << QString("G1 Y%1").arg(y_end);                    // Move Up
+    cmds << QString("G1 X%1").arg(x_start);                  // Move Left
+    cmds << QString("G1 Y%1").arg(y_start);                  // Move Down (Return)
+
+    if (m_currentConnection && m_currentConnection->isConnected()) {
+        sendCommands(cmds.join("\n"), -1);
+    }
+}
+
+// =================================================================
+// 4 Corner Navigation Buttons (TL, TR, BL, BR)
+// =================================================================
+
+// 1. Top-Left
+void frmMain::on_cmdCornerTL_clicked()
+{
+    if (m_deviceState != DeviceIdle && m_deviceState != DeviceJog) return;
+
+    double x = ui->txtHeightMapBorderX->value();
+    double y = ui->txtHeightMapBorderY->value();
+    double h = ui->txtHeightMapBorderHeight->value();
+    double safeZ = ui->txtHeightMapTraceZ->value();
+
+    double targetX = x;
+    double targetY = y + h;
+
+    QStringList cmds;
+    cmds << "G21 G90"; // Switch to Absolute mode
+    cmds << QString("G0 Z%1").arg(safeZ); // Move to specified Safe Z height
+    cmds << QString("G0 X%1 Y%2").arg(targetX).arg(targetY);
+
+    if (m_currentConnection && m_currentConnection->isConnected()) {
+        sendCommands(cmds.join("\n"), -1);
+    }
+}
+
+// 2. Top-Right
+void frmMain::on_cmdCornerTR_clicked()
+{
+    if (m_deviceState != DeviceIdle && m_deviceState != DeviceJog) return;
+
+    double x = ui->txtHeightMapBorderX->value();
+    double y = ui->txtHeightMapBorderY->value();
+    double w = ui->txtHeightMapBorderWidth->value();
+    double h = ui->txtHeightMapBorderHeight->value();
+    double safeZ = ui->txtHeightMapTraceZ->value();
+
+    double targetX = x + w;
+    double targetY = y + h;
+
+    QStringList cmds;
+    cmds << "G21 G90"; // Absolute
+    cmds << QString("G0 Z%1").arg(safeZ);
+    cmds << QString("G0 X%1 Y%2").arg(targetX).arg(targetY);
+
+    if (m_currentConnection && m_currentConnection->isConnected()) {
+        sendCommands(cmds.join("\n"), -1);
+    }
+}
+
+// 3. Bottom-Left
+void frmMain::on_cmdCornerBL_clicked()
+{
+    if (m_deviceState != DeviceIdle && m_deviceState != DeviceJog) return;
+
+    double x = ui->txtHeightMapBorderX->value();
+    double y = ui->txtHeightMapBorderY->value();
+    double safeZ = ui->txtHeightMapTraceZ->value();
+
+    double targetX = x;
+    double targetY = y;
+
+    QStringList cmds;
+    cmds << "G21 G90"; // Absolute
+    cmds << QString("G0 Z%1").arg(safeZ);
+    cmds << QString("G0 X%1 Y%2").arg(targetX).arg(targetY);
+
+    if (m_currentConnection && m_currentConnection->isConnected()) {
+        sendCommands(cmds.join("\n"), -1);
+    }
+}
+
+// 4. Bottom-Right
+void frmMain::on_cmdCornerBR_clicked()
+{
+    if (m_deviceState != DeviceIdle && m_deviceState != DeviceJog) return;
+
+    double x = ui->txtHeightMapBorderX->value();
+    double y = ui->txtHeightMapBorderY->value();
+    double w = ui->txtHeightMapBorderWidth->value();
+    double safeZ = ui->txtHeightMapTraceZ->value();
+
+    double targetX = x + w;
+    double targetY = y;
+
+    QStringList cmds;
+    cmds << "G21 G90"; // Absolute
+    cmds << QString("G0 Z%1").arg(safeZ);
+    cmds << QString("G0 X%1 Y%2").arg(targetX).arg(targetY);
+
+    if (m_currentConnection && m_currentConnection->isConnected()) {
+        sendCommands(cmds.join("\n"), -1);
+    }
+}
+
+// =================================================================
+// Move to Center Function
+// =================================================================
+void frmMain::on_cmdHeightMapCenter_clicked()
+{
+    if (m_deviceState != DeviceIdle && m_deviceState != DeviceJog) return;
+
+    double x = ui->txtHeightMapBorderX->value();
+    double y = ui->txtHeightMapBorderY->value();
+    double w = ui->txtHeightMapBorderWidth->value();
+    double h = ui->txtHeightMapBorderHeight->value();
+    double safeZ = ui->txtHeightMapTraceZ->value();
+
+    if (w <= 0 || h <= 0) return;
+
+    // Calculate center point
+    double centerX = x + (w / 2.0);
+    double centerY = y + (h / 2.0);
+
+    QStringList cmds;
+
+    // Set Absolute mode
+    cmds << "G21 G90";
+
+    // First: Rapid move to Safe Z height (to avoid surface collisions)
+    cmds << QString("G0 Z%1").arg(safeZ);
+
+    // Second: Rapid move to center coordinates
+    cmds << QString("G0 X%1 Y%2").arg(centerX).arg(centerY);
+
+    if (m_currentConnection && m_currentConnection->isConnected()) {
+        sendCommands(cmds.join("\n"), -1);
+    }
+}
+
+#include "frmmain.moc"

--- a/src/candle/frmmain.cpp
+++ b/src/candle/frmmain.cpp
@@ -6011,7 +6011,7 @@ QScriptValue frmMain::importExtension(QScriptContext *context, QScriptEngine *en
 // =================================================================
 void frmMain::on_cmdHeightMapStop_clicked()
 {
-    // Send reset command to the controller. This command stops all movements immediately.
+    // Immediate soft reset to halt all machine motion
     grblReset();
 }
 
@@ -6020,6 +6020,8 @@ void frmMain::on_cmdHeightMapStop_clicked()
 // =================================================================
 void frmMain::on_cmdHeightMapTrace_clicked()
 {
+    if (!m_currentConnection || !m_currentConnection->isConnected()) return;
+    
     if (m_deviceState != DeviceIdle && m_deviceState != DeviceJog) {
          QMessageBox::warning(this, tr("Safety Error"), tr("Device is busy. Please wait for IDLE state."));
          return;
@@ -6029,145 +6031,101 @@ void frmMain::on_cmdHeightMapTrace_clicked()
     double y = ui->txtHeightMapBorderY->value();
     double w = ui->txtHeightMapBorderWidth->value();
     double h = ui->txtHeightMapBorderHeight->value();
-
-    if (w <= 0 || h <= 0) return;
-
     double safeZ = ui->txtHeightMapTraceZ->value();
 
-    // Determine speed based on user selection
-    // Recommended values (mm/min)
+    // Validation: Ensure border area is defined
+    if (w <= 0 || h <= 0) {
+        QMessageBox::information(this, tr("HeightMap"), tr("Please define a valid border area first."));
+        return;
+    }
+
+    // Determine feed rate from UI selection (mm/min)
     int speedIndex = ui->cboTraceSpeed->currentIndex();
     double traceFeed;
-
     switch (speedIndex) {
-        case 0: traceFeed = 300.0;  break; // Slow - for high precision
-        case 1: traceFeed = 800.0;  break; // Medium
-        case 2: traceFeed = 2000.0; break; // Fast - quick but risky
+        case 0:  traceFeed = 300.0;  break; // Slow
+        case 1:  traceFeed = 800.0;  break; // Medium
+        case 2:  traceFeed = 2000.0; break; // Fast
         default: traceFeed = 500.0;
     }
 
-    // Coordinate calculation
-    double x_start = x;
-    double y_start = y;
-    double x_end = x + w;
-    double y_end = y + h;
-
     QStringList cmds;
+    cmds << "G21 G90";                      // Metric, Absolute Positioning
+    cmds << QString("G0 Z%1").arg(safeZ);   // Retract to Safe Z
+    cmds << QString("G0 X%1 Y%2").arg(x).arg(y); // Move to starting corner
 
-    // 1. Set Absolute mode (G90) and Millimeters (G21)
-    cmds << "G21 G90";
+    // Border tracing sequence
+    cmds << QString("G1 X%1 F%2").arg(x + w).arg(traceFeed);
+    cmds << QString("G1 Y%1").arg(y + h);
+    cmds << QString("G1 X%1").arg(x);
+    cmds << QString("G1 Y%1").arg(y);
 
-    // 2. Move tool up to Safe Z at maximum speed (G0)
-    cmds << QString("G0 Z%1").arg(safeZ);
-
-    // 3. Move to starting point (bottom-left corner) at maximum speed
-    cmds << QString("G0 X%1 Y%2").arg(x_start).arg(y_start);
-
-    // 4. Trace the border with user-selected speed (G1 F...)
-    cmds << QString("G1 X%1 F%2").arg(x_end).arg(traceFeed); // Move Right
-    cmds << QString("G1 Y%1").arg(y_end);                    // Move Up
-    cmds << QString("G1 X%1").arg(x_start);                  // Move Left
-    cmds << QString("G1 Y%1").arg(y_start);                  // Move Down (Return)
-
-    if (m_currentConnection && m_currentConnection->isConnected()) {
-        sendCommands(cmds.join("\n"), -1);
-    }
+    sendCommands(cmds.join("\n"), -1);
 }
 
 // =================================================================
-// 4 Corner Navigation Buttons (TL, TR, BL, BR)
+// Corner Navigation Helpers
 // =================================================================
 
-// 1. Top-Left
 void frmMain::on_cmdCornerTL_clicked()
 {
+    if (!m_currentConnection || !m_currentConnection->isConnected()) return;
     if (m_deviceState != DeviceIdle && m_deviceState != DeviceJog) return;
+    if (ui->txtHeightMapBorderWidth->value() <= 0 || ui->txtHeightMapBorderHeight->value() <= 0) return;
 
-    double x = ui->txtHeightMapBorderX->value();
-    double y = ui->txtHeightMapBorderY->value();
-    double h = ui->txtHeightMapBorderHeight->value();
+    double targetX = ui->txtHeightMapBorderX->value();
+    double targetY = ui->txtHeightMapBorderY->value() + ui->txtHeightMapBorderHeight->value();
     double safeZ = ui->txtHeightMapTraceZ->value();
 
-    double targetX = x;
-    double targetY = y + h;
-
     QStringList cmds;
-    cmds << "G21 G90"; // Switch to Absolute mode
-    cmds << QString("G0 Z%1").arg(safeZ); // Move to specified Safe Z height
-    cmds << QString("G0 X%1 Y%2").arg(targetX).arg(targetY);
-
-    if (m_currentConnection && m_currentConnection->isConnected()) {
-        sendCommands(cmds.join("\n"), -1);
-    }
+    cmds << "G21 G90" << QString("G0 Z%1").arg(safeZ) << QString("G0 X%1 Y%2").arg(targetX).arg(targetY);
+    sendCommands(cmds.join("\n"), -1);
 }
 
-// 2. Top-Right
 void frmMain::on_cmdCornerTR_clicked()
 {
+    if (!m_currentConnection || !m_currentConnection->isConnected()) return;
     if (m_deviceState != DeviceIdle && m_deviceState != DeviceJog) return;
+    if (ui->txtHeightMapBorderWidth->value() <= 0 || ui->txtHeightMapBorderHeight->value() <= 0) return;
 
-    double x = ui->txtHeightMapBorderX->value();
-    double y = ui->txtHeightMapBorderY->value();
-    double w = ui->txtHeightMapBorderWidth->value();
-    double h = ui->txtHeightMapBorderHeight->value();
+    double targetX = ui->txtHeightMapBorderX->value() + ui->txtHeightMapBorderWidth->value();
+    double targetY = ui->txtHeightMapBorderY->value() + ui->txtHeightMapBorderHeight->value();
     double safeZ = ui->txtHeightMapTraceZ->value();
 
-    double targetX = x + w;
-    double targetY = y + h;
-
     QStringList cmds;
-    cmds << "G21 G90"; // Absolute
-    cmds << QString("G0 Z%1").arg(safeZ);
-    cmds << QString("G0 X%1 Y%2").arg(targetX).arg(targetY);
-
-    if (m_currentConnection && m_currentConnection->isConnected()) {
-        sendCommands(cmds.join("\n"), -1);
-    }
+    cmds << "G21 G90" << QString("G0 Z%1").arg(safeZ) << QString("G0 X%1 Y%2").arg(targetX).arg(targetY);
+    sendCommands(cmds.join("\n"), -1);
 }
 
-// 3. Bottom-Left
 void frmMain::on_cmdCornerBL_clicked()
 {
+    if (!m_currentConnection || !m_currentConnection->isConnected()) return;
     if (m_deviceState != DeviceIdle && m_deviceState != DeviceJog) return;
+    // BL only needs X and Y, but we check width/height to ensure map is initialized
+    if (ui->txtHeightMapBorderWidth->value() <= 0 || ui->txtHeightMapBorderHeight->value() <= 0) return;
 
-    double x = ui->txtHeightMapBorderX->value();
-    double y = ui->txtHeightMapBorderY->value();
+    double targetX = ui->txtHeightMapBorderX->value();
+    double targetY = ui->txtHeightMapBorderY->value();
     double safeZ = ui->txtHeightMapTraceZ->value();
 
-    double targetX = x;
-    double targetY = y;
-
     QStringList cmds;
-    cmds << "G21 G90"; // Absolute
-    cmds << QString("G0 Z%1").arg(safeZ);
-    cmds << QString("G0 X%1 Y%2").arg(targetX).arg(targetY);
-
-    if (m_currentConnection && m_currentConnection->isConnected()) {
-        sendCommands(cmds.join("\n"), -1);
-    }
+    cmds << "G21 G90" << QString("G0 Z%1").arg(safeZ) << QString("G0 X%1 Y%2").arg(targetX).arg(targetY);
+    sendCommands(cmds.join("\n"), -1);
 }
 
-// 4. Bottom-Right
 void frmMain::on_cmdCornerBR_clicked()
 {
+    if (!m_currentConnection || !m_currentConnection->isConnected()) return;
     if (m_deviceState != DeviceIdle && m_deviceState != DeviceJog) return;
+    if (ui->txtHeightMapBorderWidth->value() <= 0 || ui->txtHeightMapBorderHeight->value() <= 0) return;
 
-    double x = ui->txtHeightMapBorderX->value();
-    double y = ui->txtHeightMapBorderY->value();
-    double w = ui->txtHeightMapBorderWidth->value();
+    double targetX = ui->txtHeightMapBorderX->value() + ui->txtHeightMapBorderWidth->value();
+    double targetY = ui->txtHeightMapBorderY->value();
     double safeZ = ui->txtHeightMapTraceZ->value();
 
-    double targetX = x + w;
-    double targetY = y;
-
     QStringList cmds;
-    cmds << "G21 G90"; // Absolute
-    cmds << QString("G0 Z%1").arg(safeZ);
-    cmds << QString("G0 X%1 Y%2").arg(targetX).arg(targetY);
-
-    if (m_currentConnection && m_currentConnection->isConnected()) {
-        sendCommands(cmds.join("\n"), -1);
-    }
+    cmds << "G21 G90" << QString("G0 Z%1").arg(safeZ) << QString("G0 X%1 Y%2").arg(targetX).arg(targetY);
+    sendCommands(cmds.join("\n"), -1);
 }
 
 // =================================================================
@@ -6175,6 +6133,7 @@ void frmMain::on_cmdCornerBR_clicked()
 // =================================================================
 void frmMain::on_cmdHeightMapCenter_clicked()
 {
+    if (!m_currentConnection || !m_currentConnection->isConnected()) return;
     if (m_deviceState != DeviceIdle && m_deviceState != DeviceJog) return;
 
     double x = ui->txtHeightMapBorderX->value();
@@ -6185,24 +6144,15 @@ void frmMain::on_cmdHeightMapCenter_clicked()
 
     if (w <= 0 || h <= 0) return;
 
-    // Calculate center point
     double centerX = x + (w / 2.0);
     double centerY = y + (h / 2.0);
 
     QStringList cmds;
-
-    // Set Absolute mode
     cmds << "G21 G90";
-
-    // First: Rapid move to Safe Z height (to avoid surface collisions)
     cmds << QString("G0 Z%1").arg(safeZ);
-
-    // Second: Rapid move to center coordinates
     cmds << QString("G0 X%1 Y%2").arg(centerX).arg(centerY);
 
-    if (m_currentConnection && m_currentConnection->isConnected()) {
-        sendCommands(cmds.join("\n"), -1);
-    }
+    sendCommands(cmds.join("\n"), -1);
 }
 
 #include "frmmain.moc"

--- a/src/candle/frmmain.h
+++ b/src/candle/frmmain.h
@@ -219,6 +219,7 @@ private slots:
     void on_cmdHeightMapLoad_clicked();
     void on_cmdHeightMapOrigin_clicked();
     void on_cmdHeightMapBorderAuto_clicked();
+	void on_cmdHeightMapTrace_clicked();
     void on_cmdHeightMapOriginTool_clicked();
     void on_cmdYPlus_pressed();
     void on_cmdYPlus_released();
@@ -244,6 +245,12 @@ private slots:
     void on_mnuViewPanels_aboutToShow();
     void on_dockVisualizer_visibilityChanged(bool visible);
     void on_sliProgram_valueChanged(int value);
+	void on_cmdCornerTL_clicked();
+    void on_cmdCornerTR_clicked();
+    void on_cmdCornerBL_clicked();
+    void on_cmdCornerBR_clicked();
+    void on_cmdHeightMapStop_clicked();
+	void on_cmdHeightMapCenter_clicked();
 
     void onConnectionDataReceived(QString data);
     void onConnectionErrorOccurred(QString error);

--- a/src/candle/frmmain.ui
+++ b/src/candle/frmmain.ui
@@ -594,678 +594,193 @@ QLabel[overrided=&quot;false&quot;] {
                 </layout>
                </item>
                <item>
-                <widget class="QWidget" name="widgetHeightmapSettings" native="true">
-                 <layout class="QVBoxLayout" name="verticalLayout_7">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <layout class="QVBoxLayout" name="verticalLayout_18">
-                    <item>
-                     <widget class="QLabel" name="label_5">
-                      <property name="text">
-                       <string>Border:</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <layout class="QGridLayout" name="gridLayout">
-                      <item row="0" column="0">
-                       <widget class="QLabel" name="label_6">
-                        <property name="text">
-                         <string>X:</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="1">
-                       <widget class="QDoubleSpinBox" name="txtHeightMapBorderX">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="locale">
-                         <locale language="C" country="AnyCountry"/>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignCenter</set>
-                        </property>
-                        <property name="buttonSymbols">
-                         <enum>QAbstractSpinBox::NoButtons</enum>
-                        </property>
-                        <property name="minimum">
-                         <double>-9999.000000000000000</double>
-                        </property>
-                        <property name="maximum">
-                         <double>9999.000000000000000</double>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="3">
-                       <widget class="QDoubleSpinBox" name="txtHeightMapBorderHeight">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="locale">
-                         <locale language="C" country="AnyCountry"/>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignCenter</set>
-                        </property>
-                        <property name="buttonSymbols">
-                         <enum>QAbstractSpinBox::NoButtons</enum>
-                        </property>
-                        <property name="minimum">
-                         <double>-9999.000000000000000</double>
-                        </property>
-                        <property name="maximum">
-                         <double>9999.000000000000000</double>
-                        </property>
-                        <property name="value">
-                         <double>10.000000000000000</double>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="2">
-                       <widget class="QLabel" name="label_9">
-                        <property name="text">
-                         <string>H:</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="1">
-                       <widget class="QDoubleSpinBox" name="txtHeightMapBorderY">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="locale">
-                         <locale language="C" country="AnyCountry"/>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignCenter</set>
-                        </property>
-                        <property name="buttonSymbols">
-                         <enum>QAbstractSpinBox::NoButtons</enum>
-                        </property>
-                        <property name="minimum">
-                         <double>-9999.000000000000000</double>
-                        </property>
-                        <property name="maximum">
-                         <double>9999.000000000000000</double>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="0">
-                       <widget class="QLabel" name="label_7">
-                        <property name="text">
-                         <string>Y:</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="2">
-                       <widget class="QLabel" name="label_8">
-                        <property name="text">
-                         <string>W:</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="3">
-                       <widget class="QDoubleSpinBox" name="txtHeightMapBorderWidth">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="locale">
-                         <locale language="C" country="AnyCountry"/>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignCenter</set>
-                        </property>
-                        <property name="buttonSymbols">
-                         <enum>QAbstractSpinBox::NoButtons</enum>
-                        </property>
-                        <property name="minimum">
-                         <double>-9999.000000000000000</double>
-                        </property>
-                        <property name="maximum">
-                         <double>9999.000000000000000</double>
-                        </property>
-                        <property name="value">
-                         <double>10.000000000000000</double>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
-                    </item>
-                    <item>
-                     <layout class="QHBoxLayout" name="horizontalLayout_18">
-                      <item>
-                       <widget class="QCheckBox" name="chkHeightMapBorderShow">
-                        <property name="text">
-                         <string>Show border</string>
-                        </property>
-                        <property name="checked">
-                         <bool>true</bool>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="StyledToolButton" name="cmdHeightMapBorderAuto">
-                        <property name="minimumSize">
-                         <size>
-                          <width>0</width>
-                          <height>0</height>
-                         </size>
-                        </property>
-                        <property name="text">
-                         <string>Auto</string>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <layout class="QVBoxLayout" name="verticalLayout_30">
-                    <item>
-                     <widget class="QLabel" name="label_27">
-                      <property name="text">
-                       <string>Origin:</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <layout class="QGridLayout" name="gridLayout_7">
-                      <item row="0" column="2">
-                       <widget class="QLabel" name="label_31">
-                        <property name="text">
-                         <string>Y:</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="1">
-                       <widget class="QDoubleSpinBox" name="txtHeightMapOriginX">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="locale">
-                         <locale language="C" country="AnyCountry"/>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignCenter</set>
-                        </property>
-                        <property name="buttonSymbols">
-                         <enum>QAbstractSpinBox::NoButtons</enum>
-                        </property>
-                        <property name="minimum">
-                         <double>-9999.000000000000000</double>
-                        </property>
-                        <property name="maximum">
-                         <double>9999.000000000000000</double>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="0">
-                       <widget class="QLabel" name="label_28">
-                        <property name="text">
-                         <string>X:</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="3">
-                       <widget class="QDoubleSpinBox" name="txtHeightMapOriginY">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="locale">
-                         <locale language="C" country="AnyCountry"/>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignCenter</set>
-                        </property>
-                        <property name="buttonSymbols">
-                         <enum>QAbstractSpinBox::NoButtons</enum>
-                        </property>
-                        <property name="minimum">
-                         <double>-9999.000000000000000</double>
-                        </property>
-                        <property name="maximum">
-                         <double>9999.000000000000000</double>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_20">
-                    <item>
-                     <widget class="QCheckBox" name="chkHeightMapOriginShow">
-                      <property name="text">
-                       <string>Show origin</string>
-                      </property>
-                      <property name="checked">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="StyledToolButton" name="cmdHeightMapOriginTool">
-                      <property name="minimumSize">
-                       <size>
-                        <width>0</width>
-                        <height>0</height>
-                       </size>
-                      </property>
-                      <property name="toolTip">
-                       <string>Use current toolhead position</string>
-                      </property>
-                      <property name="text">
-                       <string>Tool</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <layout class="QVBoxLayout" name="verticalLayout_19">
-                    <item>
-                     <widget class="QLabel" name="label_10">
-                      <property name="text">
-                       <string>Probe grid:</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <layout class="QGridLayout" name="gridLayout_4">
-                      <item row="0" column="3">
-                       <widget class="QLabel" name="label_14">
-                        <property name="text">
-                         <string>Zt:</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="0">
-                       <widget class="QLabel" name="label_12">
-                        <property name="text">
-                         <string>X:</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="1">
-                       <widget class="QDoubleSpinBox" name="txtHeightMapGridX">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="locale">
-                         <locale language="C" country="AnyCountry"/>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignCenter</set>
-                        </property>
-                        <property name="buttonSymbols">
-                         <enum>QAbstractSpinBox::NoButtons</enum>
-                        </property>
-                        <property name="decimals">
-                         <number>0</number>
-                        </property>
-                        <property name="minimum">
-                         <double>2.000000000000000</double>
-                        </property>
-                        <property name="maximum">
-                         <double>1000.000000000000000</double>
-                        </property>
-                        <property name="value">
-                         <double>2.000000000000000</double>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="5">
-                       <widget class="QDoubleSpinBox" name="txtHeightMapGridZBottom">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="locale">
-                         <locale language="C" country="AnyCountry"/>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignCenter</set>
-                        </property>
-                        <property name="buttonSymbols">
-                         <enum>QAbstractSpinBox::NoButtons</enum>
-                        </property>
-                        <property name="minimum">
-                         <double>-999.000000000000000</double>
-                        </property>
-                        <property name="maximum">
-                         <double>999.000000000000000</double>
-                        </property>
-                        <property name="value">
-                         <double>-1.000000000000000</double>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="5">
-                       <widget class="QDoubleSpinBox" name="txtHeightMapGridZTop">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="locale">
-                         <locale language="C" country="AnyCountry"/>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignCenter</set>
-                        </property>
-                        <property name="buttonSymbols">
-                         <enum>QAbstractSpinBox::NoButtons</enum>
-                        </property>
-                        <property name="minimum">
-                         <double>-999.000000000000000</double>
-                        </property>
-                        <property name="maximum">
-                         <double>999.000000000000000</double>
-                        </property>
-                        <property name="value">
-                         <double>1.000000000000000</double>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="0">
-                       <widget class="QLabel" name="label_13">
-                        <property name="text">
-                         <string>Y:</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="3">
-                       <widget class="QLabel" name="label_11">
-                        <property name="text">
-                         <string>Zb:</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="1">
-                       <widget class="QDoubleSpinBox" name="txtHeightMapGridY">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="locale">
-                         <locale language="C" country="AnyCountry"/>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignCenter</set>
-                        </property>
-                        <property name="buttonSymbols">
-                         <enum>QAbstractSpinBox::NoButtons</enum>
-                        </property>
-                        <property name="decimals">
-                         <number>0</number>
-                        </property>
-                        <property name="minimum">
-                         <double>2.000000000000000</double>
-                        </property>
-                        <property name="maximum">
-                         <double>1000.000000000000000</double>
-                        </property>
-                        <property name="value">
-                         <double>2.000000000000000</double>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="2" column="0">
-                       <widget class="QLabel" name="label_21">
-                        <property name="text">
-                         <string>F:</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="2" column="1">
-                       <widget class="QDoubleSpinBox" name="txtHeightMapProbeFeed">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="locale">
-                         <locale language="C" country="AnyCountry"/>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignCenter</set>
-                        </property>
-                        <property name="buttonSymbols">
-                         <enum>QAbstractSpinBox::NoButtons</enum>
-                        </property>
-                        <property name="decimals">
-                         <number>0</number>
-                        </property>
-                        <property name="minimum">
-                         <double>0.000000000000000</double>
-                        </property>
-                        <property name="maximum">
-                         <double>9999.000000000000000</double>
-                        </property>
-                        <property name="value">
-                         <double>0.000000000000000</double>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
-                    </item>
-                    <item>
-                     <layout class="QHBoxLayout" name="horizontalLayout_19">
-                      <item>
-                       <widget class="QCheckBox" name="chkHeightMapGridShow">
-                        <property name="text">
-                         <string>Show probe grid</string>
-                        </property>
-                        <property name="checked">
-                         <bool>true</bool>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <spacer name="horizontalSpacer_6">
-                        <property name="orientation">
-                         <enum>Qt::Horizontal</enum>
-                        </property>
-                        <property name="sizeHint" stdset="0">
-                         <size>
-                          <width>40</width>
-                          <height>1</height>
-                         </size>
-                        </property>
-                       </spacer>
-                      </item>
-                     </layout>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <layout class="QVBoxLayout" name="verticalLayout_20">
-                    <item>
-                     <widget class="QLabel" name="label_16">
-                      <property name="text">
-                       <string>Interpolation grid:</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <layout class="QGridLayout" name="gridLayout_6">
-                      <item row="1" column="2">
-                       <widget class="QLabel" name="label_19">
-                        <property name="text">
-                         <string>Y:</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="0">
-                       <widget class="QLabel" name="label_18">
-                        <property name="text">
-                         <string>X:</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="1">
-                       <widget class="QDoubleSpinBox" name="txtHeightMapInterpolationStepX">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="locale">
-                         <locale language="C" country="AnyCountry"/>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignCenter</set>
-                        </property>
-                        <property name="buttonSymbols">
-                         <enum>QAbstractSpinBox::NoButtons</enum>
-                        </property>
-                        <property name="decimals">
-                         <number>0</number>
-                        </property>
-                        <property name="minimum">
-                         <double>2.000000000000000</double>
-                        </property>
-                        <property name="maximum">
-                         <double>1000.000000000000000</double>
-                        </property>
-                        <property name="value">
-                         <double>2.000000000000000</double>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="3">
-                       <widget class="QDoubleSpinBox" name="txtHeightMapInterpolationStepY">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="locale">
-                         <locale language="C" country="AnyCountry"/>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignCenter</set>
-                        </property>
-                        <property name="buttonSymbols">
-                         <enum>QAbstractSpinBox::NoButtons</enum>
-                        </property>
-                        <property name="decimals">
-                         <number>0</number>
-                        </property>
-                        <property name="minimum">
-                         <double>2.000000000000000</double>
-                        </property>
-                        <property name="maximum">
-                         <double>1000.000000000000000</double>
-                        </property>
-                        <property name="value">
-                         <double>2.000000000000000</double>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
-                    </item>
-                    <item>
-                     <layout class="QHBoxLayout" name="horizontalLayout_23" stretch="0,0">
-                      <item>
-                       <widget class="QLabel" name="lblHeightMapInterpolationType">
-                        <property name="text">
-                         <string>Type:</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QComboBox" name="cboHeightMapInterpolationType">
-                        <property name="enabled">
-                         <bool>false</bool>
-                        </property>
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <item>
-                         <property name="text">
-                          <string>Bicubic</string>
-                         </property>
-                        </item>
-                       </widget>
-                      </item>
-                     </layout>
-                    </item>
-                    <item>
-                     <layout class="QHBoxLayout" name="horizontalLayout_24">
-                      <item>
-                       <widget class="QCheckBox" name="chkHeightMapInterpolationShow">
-                        <property name="text">
-                         <string>Show interpolation grid</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <spacer name="horizontalSpacer_8">
-                        <property name="orientation">
-                         <enum>Qt::Horizontal</enum>
-                        </property>
-                        <property name="sizeHint" stdset="0">
-                         <size>
-                          <width>40</width>
-                          <height>1</height>
-                         </size>
-                        </property>
-                       </spacer>
-                      </item>
-                     </layout>
-                    </item>
-                   </layout>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
+			<widget class="QWidget" name="widgetHeightmapSettings" native="true">
+         <layout class="QVBoxLayout" name="verticalLayout_HeightmapSettings">
+          <property name="spacing">
+           <number>6</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          
+          <item>
+           <widget class="QGroupBox" name="grpBorder">
+            <property name="title">
+             <string>Border</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_Border">
+             <property name="verticalSpacing"><number>4</number></property>
+             
+             <item row="0" column="0"><widget class="QLabel" name="label_6"><property name="text"><string>X:</string></property></widget></item>
+             <item row="0" column="1"><widget class="QDoubleSpinBox" name="txtHeightMapBorderX"><property name="sizePolicy"><sizepolicy hsizetype="Expanding" vsizetype="Fixed"><horstretch>0</horstretch><verstretch>0</verstretch></sizepolicy></property><property name="alignment"><set>Qt::AlignCenter</set></property><property name="buttonSymbols"><enum>QAbstractSpinBox::NoButtons</enum></property><property name="minimum"><double>-9999.0</double></property><property name="maximum"><double>9999.0</double></property></widget></item>
+             
+             <item row="1" column="0"><widget class="QLabel" name="label_7"><property name="text"><string>Y:</string></property></widget></item>
+             <item row="1" column="1"><widget class="QDoubleSpinBox" name="txtHeightMapBorderY"><property name="sizePolicy"><sizepolicy hsizetype="Expanding" vsizetype="Fixed"><horstretch>0</horstretch><verstretch>0</verstretch></sizepolicy></property><property name="alignment"><set>Qt::AlignCenter</set></property><property name="buttonSymbols"><enum>QAbstractSpinBox::NoButtons</enum></property><property name="minimum"><double>-9999.0</double></property><property name="maximum"><double>9999.0</double></property></widget></item>
+
+             <item row="2" column="0"><widget class="QLabel" name="label_8"><property name="text"><string>W:</string></property></widget></item>
+             <item row="2" column="1"><widget class="QDoubleSpinBox" name="txtHeightMapBorderWidth"><property name="sizePolicy"><sizepolicy hsizetype="Expanding" vsizetype="Fixed"><horstretch>0</horstretch><verstretch>0</verstretch></sizepolicy></property><property name="alignment"><set>Qt::AlignCenter</set></property><property name="buttonSymbols"><enum>QAbstractSpinBox::NoButtons</enum></property><property name="minimum"><double>-9999.0</double></property><property name="maximum"><double>9999.0</double></property><property name="value"><double>10.0</double></property></widget></item>
+
+             <item row="3" column="0"><widget class="QLabel" name="label_9"><property name="text"><string>H:</string></property></widget></item>
+             <item row="3" column="1"><widget class="QDoubleSpinBox" name="txtHeightMapBorderHeight"><property name="sizePolicy"><sizepolicy hsizetype="Expanding" vsizetype="Fixed"><horstretch>0</horstretch><verstretch>0</verstretch></sizepolicy></property><property name="alignment"><set>Qt::AlignCenter</set></property><property name="buttonSymbols"><enum>QAbstractSpinBox::NoButtons</enum></property><property name="minimum"><double>-9999.0</double></property><property name="maximum"><double>9999.0</double></property><property name="value"><double>10.0</double></property></widget></item>
+             
+             <item row="4" column="0" colspan="1"><widget class="QCheckBox" name="chkHeightMapBorderShow"><property name="text"><string>Show</string></property><property name="checked"><bool>true</bool></property></widget></item>
+             <item row="4" column="1"><widget class="StyledToolButton" name="cmdHeightMapBorderAuto"><property name="text"><string>Auto</string></property></widget></item>
+            </layout>
+           </widget>
+          </item>
+		  <item>
+           <widget class="QGroupBox" name="grpTraceActions">
+            <property name="title">
+             <string>Trace &amp; Control</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_Trace">
+             <property name="verticalSpacing"><number>5</number></property>
+             <property name="horizontalSpacing"><number>5</number></property>
+
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_TraceZ">
+               <property name="text"><string>Z:</string></property>
+               <property name="alignment"><set>Qt::AlignRight|Qt::AlignVCenter</set></property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QDoubleSpinBox" name="txtHeightMapTraceZ">
+               <property name="sizePolicy"><sizepolicy hsizetype="Expanding" vsizetype="Fixed"><horstretch>0</horstretch><verstretch>0</verstretch></sizepolicy></property>
+               <property name="alignment"><set>Qt::AlignCenter</set></property>
+               <property name="buttonSymbols"><enum>QAbstractSpinBox::NoButtons</enum></property>
+               <property name="decimals"><number>1</number></property>
+               <property name="minimum"><double>1.0</double></property>
+               <property name="maximum"><double>50.0</double></property>
+               <property name="value"><double>5.0</double></property>
+              </widget>
+             </item>
+             <item row="0" column="2">
+              <widget class="QLabel" name="label_TraceFeed">
+               <property name="text"><string>Spd:</string></property>
+               <property name="alignment"><set>Qt::AlignRight|Qt::AlignVCenter</set></property>
+              </widget>
+             </item>
+             <item row="0" column="3">
+              <widget class="QComboBox" name="cboTraceSpeed">
+               <property name="sizePolicy"><sizepolicy hsizetype="Expanding" vsizetype="Fixed"><horstretch>0</horstretch><verstretch>0</verstretch></sizepolicy></property>
+               <property name="toolTip"><string>Speed</string></property>
+               <item><property name="text"><string>Slow</string></property></item>
+               <item><property name="text"><string>Med</string></property></item>
+               <item><property name="text"><string>Fast</string></property></item>
+              </widget>
+             </item>
+
+             <item row="1" column="0" colspan="2">
+              <widget class="StyledToolButton" name="cmdHeightMapTrace">
+               <property name="sizePolicy"><sizepolicy hsizetype="Preferred" vsizetype="Fixed"><horstretch>1</horstretch><verstretch>0</verstretch></sizepolicy></property>
+               <property name="text"><string>Trace</string></property>
+               <property name="icon"><iconset resource="images.qrc"><normaloff>:/images/fit_1.png</normaloff>:/images/fit_1.png</iconset></property>
+              </widget>
+             </item>
+             <item row="1" column="2" colspan="2">
+              <widget class="StyledToolButton" name="cmdHeightMapStop">
+               <property name="sizePolicy"><sizepolicy hsizetype="Preferred" vsizetype="Fixed"><horstretch>1</horstretch><verstretch>0</verstretch></sizepolicy></property>
+               <property name="text"><string>STOP</string></property>
+               <property name="icon"><iconset resource="images.qrc"><normaloff>:/images/brake.png</normaloff>:/images/brake.png</iconset></property>
+               <property name="styleSheet"><string notr="true">color: red; font-weight: bold;</string></property>
+              </widget>
+             </item>
+
+             <item row="2" column="0" colspan="4">
+              <widget class="StyledToolButton" name="cmdHeightMapCenter">
+               <property name="sizePolicy"><sizepolicy hsizetype="Preferred" vsizetype="Fixed"><horstretch>0</horstretch><verstretch>0</verstretch></sizepolicy></property>
+               <property name="text"><string>Go to Center ✛</string></property>
+               <property name="toolTip"><string>Move to center of the border</string></property>
+              </widget>
+             </item>
+
+             <item row="3" column="0" colspan="2"><widget class="StyledToolButton" name="cmdCornerTL"><property name="sizePolicy"><sizepolicy hsizetype="Preferred" vsizetype="Fixed"><horstretch>0</horstretch><verstretch>0</verstretch></sizepolicy></property><property name="text"><string>TL ↖</string></property></widget></item>
+             <item row="3" column="2" colspan="2"><widget class="StyledToolButton" name="cmdCornerTR"><property name="sizePolicy"><sizepolicy hsizetype="Preferred" vsizetype="Fixed"><horstretch>0</horstretch><verstretch>0</verstretch></sizepolicy></property><property name="text"><string>TR ↗</string></property></widget></item>
+
+             <item row="4" column="0" colspan="2"><widget class="StyledToolButton" name="cmdCornerBL"><property name="sizePolicy"><sizepolicy hsizetype="Preferred" vsizetype="Fixed"><horstretch>0</horstretch><verstretch>0</verstretch></sizepolicy></property><property name="text"><string>BL ↙</string></property></widget></item>
+             <item row="4" column="2" colspan="2"><widget class="StyledToolButton" name="cmdCornerBR"><property name="sizePolicy"><sizepolicy hsizetype="Preferred" vsizetype="Fixed"><horstretch>0</horstretch><verstretch>0</verstretch></sizepolicy></property><property name="text"><string>BR ↘</string></property></widget></item>
+
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="grpProbe">
+             <property name="title"><string>Probe Grid</string></property>
+             <layout class="QGridLayout" name="gridLayout_Probe">
+               <property name="verticalSpacing"><number>4</number></property>
+               
+               <item row="0" column="0"><widget class="QLabel" name="label_12"><property name="text"><string>Points X:</string></property></widget></item>
+               <item row="0" column="1"><widget class="QDoubleSpinBox" name="txtHeightMapGridX"><property name="alignment"><set>Qt::AlignCenter</set></property><property name="buttonSymbols"><enum>QAbstractSpinBox::NoButtons</enum></property><property name="decimals"><number>0</number></property><property name="minimum"><double>2.0</double></property><property name="value"><double>2.0</double></property></widget></item>
+               
+               <item row="1" column="0"><widget class="QLabel" name="label_13"><property name="text"><string>Points Y:</string></property></widget></item>
+               <item row="1" column="1"><widget class="QDoubleSpinBox" name="txtHeightMapGridY"><property name="alignment"><set>Qt::AlignCenter</set></property><property name="buttonSymbols"><enum>QAbstractSpinBox::NoButtons</enum></property><property name="decimals"><number>0</number></property><property name="minimum"><double>2.0</double></property><property name="value"><double>2.0</double></property></widget></item>
+               
+               <item row="2" column="0"><widget class="QLabel" name="label_14"><property name="text"><string>Z Top:</string></property></widget></item>
+               <item row="2" column="1"><widget class="QDoubleSpinBox" name="txtHeightMapGridZTop"><property name="alignment"><set>Qt::AlignCenter</set></property><property name="buttonSymbols"><enum>QAbstractSpinBox::NoButtons</enum></property><property name="minimum"><double>-999.0</double></property><property name="value"><double>1.0</double></property></widget></item>
+               
+               <item row="3" column="0"><widget class="QLabel" name="label_11"><property name="text"><string>Z Btm:</string></property></widget></item>
+               <item row="3" column="1"><widget class="QDoubleSpinBox" name="txtHeightMapGridZBottom"><property name="alignment"><set>Qt::AlignCenter</set></property><property name="buttonSymbols"><enum>QAbstractSpinBox::NoButtons</enum></property><property name="minimum"><double>-999.0</double></property><property name="value"><double>-1.0</double></property></widget></item>
+               
+               <item row="4" column="0"><widget class="QLabel" name="label_21"><property name="text"><string>Feed:</string></property></widget></item>
+               <item row="4" column="1"><widget class="QDoubleSpinBox" name="txtHeightMapProbeFeed"><property name="alignment"><set>Qt::AlignCenter</set></property><property name="buttonSymbols"><enum>QAbstractSpinBox::NoButtons</enum></property><property name="decimals"><number>0</number></property><property name="maximum"><double>9999.0</double></property><property name="value"><double>10.0</double></property></widget></item>
+
+               <item row="5" column="0" colspan="2"><widget class="QCheckBox" name="chkHeightMapGridShow"><property name="text"><string>Show grid</string></property><property name="checked"><bool>true</bool></property></widget></item>
+             </layout>
+           </widget>
+          </item>
+
+          <item>
+             <widget class="QGroupBox" name="grpInterp">
+               <property name="title"><string>Interpolation</string></property>
+               <layout class="QGridLayout" name="gridLayout_Interp">
+                 <item row="0" column="0"><widget class="QLabel" name="label_18"><property name="text"><string>Step X:</string></property></widget></item>
+                 <item row="0" column="1"><widget class="QDoubleSpinBox" name="txtHeightMapInterpolationStepX"><property name="alignment"><set>Qt::AlignCenter</set></property><property name="buttonSymbols"><enum>QAbstractSpinBox::NoButtons</enum></property><property name="decimals"><number>0</number></property><property name="minimum"><double>2.0</double></property><property name="value"><double>2.0</double></property></widget></item>
+                 
+                 <item row="1" column="0"><widget class="QLabel" name="label_19"><property name="text"><string>Step Y:</string></property></widget></item>
+                 <item row="1" column="1"><widget class="QDoubleSpinBox" name="txtHeightMapInterpolationStepY"><property name="alignment"><set>Qt::AlignCenter</set></property><property name="buttonSymbols"><enum>QAbstractSpinBox::NoButtons</enum></property><property name="decimals"><number>0</number></property><property name="minimum"><double>2.0</double></property><property name="value"><double>2.0</double></property></widget></item>
+                 
+                 <item row="2" column="0"><widget class="QLabel" name="lblHeightMapInterpolationType"><property name="text"><string>Type:</string></property></widget></item>
+                 <item row="2" column="1">
+                   <widget class="QComboBox" name="cboHeightMapInterpolationType">
+                    <property name="enabled"><bool>false</bool></property>
+                    <item><property name="text"><string>Bicubic</string></property></item>
+                   </widget>
+                 </item>
+                 <item row="3" column="0" colspan="2">
+                   <widget class="QCheckBox" name="chkHeightMapInterpolationShow"><property name="text"><string>Show interp. grid</string></property><property name="checked"><bool>true</bool></property></widget>
+                 </item>
+               </layout>
+             </widget>
+          </item>
+
+          <item>
+             <widget class="QGroupBox" name="grpOrigin">
+               <property name="title"><string>Origin</string></property>
+               <layout class="QGridLayout" name="gridLayout_Origin">
+                 <item row="0" column="0"><widget class="QLabel" name="label_28"><property name="text"><string>X:</string></property></widget></item>
+                 <item row="0" column="1"><widget class="QDoubleSpinBox" name="txtHeightMapOriginX"><property name="alignment"><set>Qt::AlignCenter</set></property><property name="buttonSymbols"><enum>QAbstractSpinBox::NoButtons</enum></property><property name="minimum"><double>-9999.0</double></property><property name="maximum"><double>9999.0</double></property></widget></item>
+                 
+                 <item row="1" column="0"><widget class="QLabel" name="label_31"><property name="text"><string>Y:</string></property></widget></item>
+                 <item row="1" column="1"><widget class="QDoubleSpinBox" name="txtHeightMapOriginY"><property name="alignment"><set>Qt::AlignCenter</set></property><property name="buttonSymbols"><enum>QAbstractSpinBox::NoButtons</enum></property><property name="minimum"><double>-9999.0</double></property><property name="maximum"><double>9999.0</double></property></widget></item>
+                 
+                 <item row="2" column="0"><widget class="QCheckBox" name="chkHeightMapOriginShow"><property name="text"><string>Show</string></property><property name="checked"><bool>true</bool></property></widget></item>
+                 <item row="2" column="1"><widget class="StyledToolButton" name="cmdHeightMapOriginTool"><property name="text"><string>To Tool</string></property></widget></item>
+               </layout>
+             </widget>
+          </item>
+
+         </layout>
+        </widget>
+			   </item>
               </layout>
              </widget>
             </item>


### PR DESCRIPTION
Hello, 
I've added some practical features to the HeightMap section to improve the user experience:
1. **Corner Navigation:** Added buttons to move the probe directly to TL, TR, BL, and BR corners.
2. **Move to Center:** Quick navigation to the center of the height map area.
3. **Trace Speed Control:** Added a dropdown to select tracing speed (Slow, Medium, Fast).
4. **Safety:** All navigation moves include a retraction to Safe Z.
<img width="220" height="530" alt="image" src="https://github.com/user-attachments/assets/5f23b5d8-15c1-43e3-8b96-5ff97692fd17" />
