### PR TITLE
Adapt files layout for RPM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,17 @@ project(Candle VERSION 11.2)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 
+# Include GNUInstallDirs for standard path variables
+include(GNUInstallDirs)
+
+# Determine if we should use standard Linux paths (for distro packaging)
+# Default is false (portable installation)
+if(CMAKE_INSTALL_PREFIX MATCHES "^/usr")
+    set(CANDLE_USE_STANDARD_PATHS TRUE)
+else()
+    set(CANDLE_USE_STANDARD_PATHS FALSE)
+endif()
+
 if(MSVC)
     add_compile_options(/MP)
 endif()

--- a/src/candle/CMakeLists.txt
+++ b/src/candle/CMakeLists.txt
@@ -1,12 +1,17 @@
 set(APP_NAME ${PROJECT_NAME})
 set(APP_VERSION ${PROJECT_VERSION})
 
+# Try to get build number from git, fallback to "unknown"
 execute_process(
   COMMAND git log -1 --format=%h
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   OUTPUT_VARIABLE BUILD_NUMBER
   OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_QUIET
 )
+if(NOT BUILD_NUMBER)
+  set(BUILD_NUMBER "unknown")
+endif()
 
 configure_file(versionconfig.h.in versionconfig.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
@@ -46,7 +51,14 @@ elseif(APPLE)
     )
 elseif(UNIX)
     add_executable(candle ${SRC_FILES} ${RSC_FILES} ${QM_FILES} icon.rc)
-    set_target_properties(candle PROPERTIES INSTALL_RPATH "$ORIGIN/lib")
+    if(CANDLE_USE_STANDARD_PATHS)
+        # Calculate relative path from bindir to libdir/candle
+        file(RELATIVE_PATH _lib_rel_path ${CMAKE_INSTALL_FULL_BINDIR} ${CMAKE_INSTALL_FULL_LIBDIR})
+        set_target_properties(candle PROPERTIES INSTALL_RPATH "$ORIGIN/${_lib_rel_path}/candle")
+        unset(_lib_rel_path)
+    else()
+        set_target_properties(candle PROPERTIES INSTALL_RPATH "$ORIGIN/lib")
+    endif()
 endif()
 
 target_include_directories(candle PRIVATE . ../customwidgets)
@@ -56,11 +68,32 @@ target_compile_definitions(candle PRIVATE
         QT_NO_DEBUG
 )
 
+# Add path definitions for resources
+if(CANDLE_USE_STANDARD_PATHS)
+    target_compile_definitions(candle PRIVATE
+        CANDLE_TRANSLATIONS_DIR="${CMAKE_INSTALL_FULL_DATADIR}/candle/translations"
+        CANDLE_PLUGINS_DIR="${CMAKE_INSTALL_FULL_LIBDIR}/candle/candleplugins"
+        CANDLE_SCRIPT_PLUGINS_DIR="${CMAKE_INSTALL_FULL_LIBDIR}/candle/plugins/script"
+        CANDLE_DOCS_DIR="${CMAKE_INSTALL_FULL_DOCDIR}"
+        CANDLE_DATA_DIR="${CMAKE_INSTALL_FULL_DATADIR}/candle"
+    )
+else()
+    target_compile_definitions(candle PRIVATE
+        CANDLE_TRANSLATIONS_DIR=""
+        CANDLE_PLUGINS_DIR=""
+        CANDLE_SCRIPT_PLUGINS_DIR=""
+        CANDLE_DOCS_DIR=""
+        CANDLE_DATA_DIR=""
+    )
+endif()
+
 target_link_libraries(candle PRIVATE customwidgets Qt5::Core Qt5::Widgets Qt5::OpenGL Qt5::SerialPort Qt5::Script Qt5::ScriptTools Qt5::Network Qt5::WebSockets Qt5::Help)
 
 # Main executable
 if(APPLE)
     install(TARGETS candle BUNDLE DESTINATION .)
+elseif(CANDLE_USE_STANDARD_PATHS)
+    install(TARGETS candle RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 else()
     install(TARGETS candle RUNTIME DESTINATION .)
 endif()
@@ -68,6 +101,8 @@ endif()
 # Translations
 if(APPLE)
     set(TRANSLATIONS_DESTINATION "Candle.app/Contents/MacOS/translations")
+elseif(CANDLE_USE_STANDARD_PATHS)
+    set(TRANSLATIONS_DESTINATION ${CMAKE_INSTALL_DATADIR}/candle/translations)
 else()
     set(TRANSLATIONS_DESTINATION "translations")
 endif()
@@ -75,41 +110,46 @@ endif()
 install(FILES ${QM_FILES} DESTINATION ${TRANSLATIONS_DESTINATION})
 
 # Base translations
-get_target_property(QT5_QMAKE_EXECUTABLE Qt5::qmake IMPORTED_LOCATION)
-execute_process(
-    COMMAND "${QT5_QMAKE_EXECUTABLE}" -query QT_INSTALL_TRANSLATIONS
-    OUTPUT_VARIABLE QT_TRANSLATIONS_DIR
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+# For system-wide installation, rely on system Qt translations instead of copying them
+if(NOT CANDLE_USE_STANDARD_PATHS)
+    get_target_property(QT5_QMAKE_EXECUTABLE Qt5::qmake IMPORTED_LOCATION)
+    execute_process(
+        COMMAND "${QT5_QMAKE_EXECUTABLE}" -query QT_INSTALL_TRANSLATIONS
+        OUTPUT_VARIABLE QT_TRANSLATIONS_DIR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
 
-set(QT_LANGUAGES ru es fr pt)
+    set(QT_LANGUAGES ru es fr pt)
 
-foreach(LANG ${QT_LANGUAGES})
-    set(QT_TRANSLATION_FILE_BASE "${QT_TRANSLATIONS_DIR}/qtbase_${LANG}.qm")
-    if(EXISTS "${QT_TRANSLATION_FILE_BASE}")
-        install(
-            FILES "${QT_TRANSLATION_FILE_BASE}"
-            DESTINATION ${TRANSLATIONS_DESTINATION}
-        )
-    endif()
-    set(QT_TRANSLATION_FILE_SCRIPT "${QT_TRANSLATIONS_DIR}/qtscript_${LANG}.qm")
-    if(EXISTS "${QT_TRANSLATION_FILE_SCRIPT}")
-        install(
-            FILES "${QT_TRANSLATION_FILE_SCRIPT}"
-            DESTINATION ${TRANSLATIONS_DESTINATION}
-        )
-    endif()    
-    set(QT_TRANSLATION_FILE_HELP "${QT_TRANSLATIONS_DIR}/qt_help_${LANG}.qm")
-    if(EXISTS "${QT_TRANSLATION_FILE_HELP}")
-        install(
-            FILES "${QT_TRANSLATION_FILE_HELP}"
-            DESTINATION ${TRANSLATIONS_DESTINATION}
-        )
-    endif()    
-endforeach()
+    foreach(LANG ${QT_LANGUAGES})
+        set(QT_TRANSLATION_FILE_BASE "${QT_TRANSLATIONS_DIR}/qtbase_${LANG}.qm")
+        if(EXISTS "${QT_TRANSLATION_FILE_BASE}")
+            install(
+                FILES "${QT_TRANSLATION_FILE_BASE}"
+                DESTINATION ${TRANSLATIONS_DESTINATION}
+            )
+        endif()
+        set(QT_TRANSLATION_FILE_SCRIPT "${QT_TRANSLATIONS_DIR}/qtscript_${LANG}.qm")
+        if(EXISTS "${QT_TRANSLATION_FILE_SCRIPT}")
+            install(
+                FILES "${QT_TRANSLATION_FILE_SCRIPT}"
+                DESTINATION ${TRANSLATIONS_DESTINATION}
+            )
+        endif()
+        set(QT_TRANSLATION_FILE_HELP "${QT_TRANSLATIONS_DIR}/qt_help_${LANG}.qm")
+        if(EXISTS "${QT_TRANSLATION_FILE_HELP}")
+            install(
+                FILES "${QT_TRANSLATION_FILE_HELP}"
+                DESTINATION ${TRANSLATIONS_DESTINATION}
+            )
+        endif()
+    endforeach()
+endif()
 
 if(APPLE)
     set(GENERAL_DESTINATION "Candle.app/Contents/MacOS")
+elseif(CANDLE_USE_STANDARD_PATHS)
+    set(GENERAL_DESTINATION ${CMAKE_INSTALL_DATADIR}/candle)
 else()
     set(GENERAL_DESTINATION ".")
 endif()
@@ -138,18 +178,37 @@ add_custom_target(
 
 # Install
 # Candle plugins
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/candleplugins
-    DESTINATION ${GENERAL_DESTINATION}
-    FILES_MATCHING
-    PATTERN *.*
-    PATTERN *.pro EXCLUDE
-)
+if(CANDLE_USE_STANDARD_PATHS)
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/candleplugins
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/candle
+        FILES_MATCHING
+        PATTERN *.*
+        PATTERN *.pro EXCLUDE
+        PATTERN *.ts EXCLUDE
+    )
+else()
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/candleplugins
+        DESTINATION ${GENERAL_DESTINATION}
+        FILES_MATCHING
+        PATTERN *.*
+        PATTERN *.pro EXCLUDE
+        PATTERN *.ts EXCLUDE
+    )
+endif()
 
 # License
-install(FILES ${CMAKE_SOURCE_DIR}/LICENSE DESTINATION ${GENERAL_DESTINATION})
+if(CANDLE_USE_STANDARD_PATHS)
+    install(FILES ${CMAKE_SOURCE_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_DOCDIR})
+else()
+    install(FILES ${CMAKE_SOURCE_DIR}/LICENSE DESTINATION ${GENERAL_DESTINATION})
+endif()
 
 # Documentation
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/help DESTINATION ${GENERAL_DESTINATION} FILES_MATCHING PATTERN *.qch PATTERN *.qhc)
+if(CANDLE_USE_STANDARD_PATHS)
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/help DESTINATION ${CMAKE_INSTALL_DOCDIR} FILES_MATCHING PATTERN *.qch PATTERN *.qhc)
+else()
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/help DESTINATION ${GENERAL_DESTINATION} FILES_MATCHING PATTERN *.qch PATTERN *.qhc)
+endif()
  
 # Shared libraries
 if(WIN32)

--- a/src/candle/candlepaths.h
+++ b/src/candle/candlepaths.h
@@ -1,0 +1,37 @@
+#ifndef CANDLEPATHS_H
+#define CANDLEPATHS_H
+
+#include <QString>
+#include <QApplication>
+
+static inline QString candleTranslationsDir()
+{
+    QString dir = CANDLE_TRANSLATIONS_DIR;
+    return dir.isEmpty() ? qApp->applicationDirPath() + "/translations" : dir;
+}
+
+static inline QString candlePluginsDir()
+{
+    QString dir = CANDLE_PLUGINS_DIR;
+    return dir.isEmpty() ? qApp->applicationDirPath() + "/candleplugins" : dir;
+}
+
+static inline QString candleScriptPluginsDir()
+{
+    QString dir = CANDLE_SCRIPT_PLUGINS_DIR;
+    return dir.isEmpty() ? qApp->applicationDirPath() + "/plugins/script" : dir;
+}
+
+static inline QString candleDocsDir()
+{
+    QString dir = CANDLE_DOCS_DIR;
+    return dir.isEmpty() ? qApp->applicationDirPath() : dir;
+}
+
+static inline QString candleDataDir()
+{
+    QString dir = CANDLE_DATA_DIR;
+    return dir.isEmpty() ? qApp->applicationDirPath() : dir;
+}
+
+#endif // CANDLEPATHS_H

--- a/src/candle/frmabout.cpp
+++ b/src/candle/frmabout.cpp
@@ -4,6 +4,7 @@
 #include <QDesktopServices>
 #include "frmabout.h"
 #include "ui_frmabout.h"
+#include "candlepaths.h"
 #include "versionconfig.h"
 
 frmAbout::frmAbout(QWidget *parent) :
@@ -18,7 +19,7 @@ frmAbout::frmAbout(QWidget *parent) :
         .arg(BUILD_NUMBER)
     );
 
-    QFile file(qApp->applicationDirPath() + "/LICENSE");
+    QFile file(candleDocsDir() + "/LICENSE");
 
     if (file.open(QIODevice::ReadOnly)) {
         ui->txtLicense->setPlainText(file.readAll());

--- a/src/candle/frmhelp.cpp
+++ b/src/candle/frmhelp.cpp
@@ -1,5 +1,6 @@
 #include "frmhelp.h"
 #include "ui_frmhelp.h"
+#include "candlepaths.h"
 #include <QDebug>
 #include <QSplitter>
 #include <QVBoxLayout>
@@ -124,7 +125,7 @@ void frmHelp::showSearchWidget(bool visible)
 
 QString frmHelp::prepareHelpFiles()
 {
-    auto baseDir = qApp->applicationDirPath() + "/help";
+    auto baseDir = candleDocsDir() + "/help";
     auto dataDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/help";
     auto baseCollectionFile = baseDir + "/candle.qhc";
     auto dataCollectionFile = dataDir + "/candle.qhc";

--- a/src/candle/frmmain.cpp
+++ b/src/candle/frmmain.cpp
@@ -27,6 +27,7 @@
 #include "ui_frmmain.h"
 #include "ui_frmsettings.h"
 #include "frmchecklist.h"
+#include "candlepaths.h"
 #include "widgets/widgetmimedata.h"
 #include "loggingcategories.h"
 #include "settingsprofileentry.h"
@@ -3231,7 +3232,7 @@ void frmMain::onBeforeScriptStart(QScriptEngine &engine)
     // Delegate objects
     // App
     QScriptValue app = engine.newQObject(m_scriptApp);
-    app.setProperty("path", qApp->applicationDirPath());
+    app.setProperty("path", candleDataDir());
     engine.globalObject().setProperty("app", app);
 
     // Settings
@@ -4233,7 +4234,7 @@ void frmMain::applySettings()
 
 void frmMain::loadPlugins()
 {
-    QString pluginsDir = qApp->applicationDirPath() + "/candleplugins/";
+    QString pluginsDir = candlePluginsDir();
 
     // Get plugins list
     QStringList pl = QDir(pluginsDir).entryList(QDir::Dirs | QDir::NoDotAndDotDot);
@@ -4271,7 +4272,7 @@ void frmMain::loadPlugins()
             // Delegate objects
             // App
             QScriptValue app = se->newQObject(m_scriptApp);
-            app.setProperty("path", qApp->applicationDirPath());
+            app.setProperty("path", candleDataDir());
             se->globalObject().setProperty("app", app);
 
             // Settings

--- a/src/candle/frmsettings.cpp
+++ b/src/candle/frmsettings.cpp
@@ -3,6 +3,7 @@
 
 #include "frmsettings.h"
 #include "ui_frmsettings.h"
+#include "candlepaths.h"
 #include <QtSerialPort/QSerialPort>
 #include <QtSerialPort/QSerialPortInfo>
 #include <QDebug>
@@ -86,7 +87,7 @@ frmSettings::frmSettings(QWidget *parent) :
     searchPorts();
 
     // Languages
-    QDir d(qApp->applicationDirPath() + "/translations");
+    QDir d(candleTranslationsDir());
     QStringList fl = QStringList() << "candle_*.qm";
     QStringList tl = d.entryList(fl, QDir::Files);
     QRegExp fx("_([^\\.]+)");

--- a/src/candle/main.cpp
+++ b/src/candle/main.cpp
@@ -17,12 +17,13 @@
 #include "parser/gcodeviewparse.h"
 #include "fileloghandler.h"
 #include "versionconfig.h"
+#include "candlepaths.h"
 
 #include "frmmain.h"
 
 void loadTranslationsForLocale(const QString &locale, QCoreApplication &app)
 {
-    auto translationsFolder = qApp->applicationDirPath() + "/translations/";
+    QString translationsFolder = candleTranslationsDir();
     QDir dir(translationsFolder);
 
     if (!dir.exists())
@@ -51,6 +52,9 @@ int main(int argc, char *argv[])
     a.setApplicationName(APP_NAME);
     a.setApplicationDisplayName(APP_NAME);
     a.setApplicationVersion(APP_VERSION);
+
+    // Add script plugin library path for QtScript extensions
+    a.addLibraryPath(candleScriptPluginsDir());
 
     installFileLogHandler();
 

--- a/src/customwidgets/CMakeLists.txt
+++ b/src/customwidgets/CMakeLists.txt
@@ -12,6 +12,8 @@ target_link_libraries(customwidgets PRIVATE Qt5::Core Qt5::Widgets)
 
 if(APPLE)
     install(TARGETS customwidgets LIBRARY DESTINATION Candle.app/Contents/Frameworks)
+elseif(CANDLE_USE_STANDARD_PATHS)
+    install(TARGETS customwidgets LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/candle)
 else()
     install(TARGETS customwidgets RUNTIME DESTINATION .)
 endif()

--- a/src/designerplugins/CMakeLists.txt
+++ b/src/designerplugins/CMakeLists.txt
@@ -1,5 +1,7 @@
 if(APPLE)
     set(DESIGNER_DESTINATION "Candle.app/Contents/MacOS/designerplugins")
+elseif(CANDLE_USE_STANDARD_PATHS)
+    set(DESIGNER_DESTINATION ${CMAKE_INSTALL_LIBDIR}/candle/designerplugins)
 else()
     set(DESIGNER_DESTINATION "designerplugins")
 endif()

--- a/src/scriptbindings/qtbindings/CMakeLists.txt
+++ b/src/scriptbindings/qtbindings/CMakeLists.txt
@@ -1,5 +1,7 @@
 if(APPLE)
     set(SCRIPT_DESTINATION "Candle.app/Contents/MacOS/script")
+elseif(CANDLE_USE_STANDARD_PATHS)
+    set(SCRIPT_DESTINATION ${CMAKE_INSTALL_LIBDIR}/candle/plugins/script)
 else()
     set(SCRIPT_DESTINATION "script")
 endif()


### PR DESCRIPTION
Добрый день!
Опакечивал актуальную версию Candle в RPM для репозитория дистрибутива Роса (и МОС) и столкнулся с тем, что применяемый здесь подход положить все файлы в одну папку не подходит для дистрибутивного опакечивания.
Постарался сделать патч так, чтобы сохранить возможность использовать текущий подход и сделать возможным правильное раскладывание файлов при опакечивании.

Получается вот такой пакет:

```
$ rpm -ql candle
/usr/bin/candle
/usr/lib64/candle
/usr/lib64/candle/candleplugins
/usr/lib64/candle/candleplugins/camera
/usr/lib64/candle/candleplugins/camera/config.ini
/usr/lib64/candle/candleplugins/camera/script.js
/usr/lib64/candle/candleplugins/camera/settings.ui
/usr/lib64/candle/candleplugins/camera/translation_ru.qm
/usr/lib64/candle/candleplugins/camera/widget.ui
/usr/lib64/candle/candleplugins/coordinatesystem
/usr/lib64/candle/candleplugins/coordinatesystem/config.ini
/usr/lib64/candle/candleplugins/coordinatesystem/images
/usr/lib64/candle/candleplugins/coordinatesystem/images/0.png
/usr/lib64/candle/candleplugins/coordinatesystem/images/54.png
/usr/lib64/candle/candleplugins/coordinatesystem/images/55.png
/usr/lib64/candle/candleplugins/coordinatesystem/images/56.png
/usr/lib64/candle/candleplugins/coordinatesystem/images/57.png
/usr/lib64/candle/candleplugins/coordinatesystem/images/58.png
/usr/lib64/candle/candleplugins/coordinatesystem/images/59.png
/usr/lib64/candle/candleplugins/coordinatesystem/images/a0.png
/usr/lib64/candle/candleplugins/coordinatesystem/images/all0.png
/usr/lib64/candle/candleplugins/coordinatesystem/images/all01.png
/usr/lib64/candle/candleplugins/coordinatesystem/images/x0.png
/usr/lib64/candle/candleplugins/coordinatesystem/images/y0.png
/usr/lib64/candle/candleplugins/coordinatesystem/images/z0.png
/usr/lib64/candle/candleplugins/coordinatesystem/script.js
/usr/lib64/candle/candleplugins/coordinatesystem/translation_ru.qm
/usr/lib64/candle/candleplugins/coordinatesystem/widget.ui
/usr/lib64/candle/candleplugins/emergencybutton
/usr/lib64/candle/candleplugins/emergencybutton/config.ini
/usr/lib64/candle/candleplugins/emergencybutton/images
/usr/lib64/candle/candleplugins/emergencybutton/images/stop.png
/usr/lib64/candle/candleplugins/emergencybutton/script.js
/usr/lib64/candle/candleplugins/emergencybutton/translation_ru.qm
/usr/lib64/candle/candleplugins/emergencybutton/widget.ui
/usr/lib64/candle/candleplugins/usercommands
/usr/lib64/candle/candleplugins/usercommands/config.ini
/usr/lib64/candle/candleplugins/usercommands/images
/usr/lib64/candle/candleplugins/usercommands/images/axis_return.png
/usr/lib64/candle/candleplugins/usercommands/images/axis_zero.png
/usr/lib64/candle/candleplugins/usercommands/images/camera.png
/usr/lib64/candle/candleplugins/usercommands/images/cutter.png
/usr/lib64/candle/candleplugins/usercommands/images/guard.png
/usr/lib64/candle/candleplugins/usercommands/images/num1.png
/usr/lib64/candle/candleplugins/usercommands/images/num2.png
/usr/lib64/candle/candleplugins/usercommands/images/num3.png
/usr/lib64/candle/candleplugins/usercommands/images/num4.png
/usr/lib64/candle/candleplugins/usercommands/images/origin.png
/usr/lib64/candle/candleplugins/usercommands/images/run.png
/usr/lib64/candle/candleplugins/usercommands/images/safe_z.png
/usr/lib64/candle/candleplugins/usercommands/images/search_for_z.png
/usr/lib64/candle/candleplugins/usercommands/images/zero_z.png
/usr/lib64/candle/candleplugins/usercommands/import.ui
/usr/lib64/candle/candleplugins/usercommands/script.js
/usr/lib64/candle/candleplugins/usercommands/settings.ini
/usr/lib64/candle/candleplugins/usercommands/settings.ui
/usr/lib64/candle/candleplugins/usercommands/translation_ru.qm
/usr/lib64/candle/candleplugins/usercommands/widget.ui
/usr/lib64/candle/designerplugins
/usr/lib64/candle/designerplugins/libcameraplugin.so
/usr/lib64/candle/designerplugins/libcustomwidgetsplugin.so
/usr/lib64/candle/libcustomwidgets.so
/usr/lib64/candle/plugins
/usr/lib64/candle/plugins/script
/usr/lib64/candle/plugins/script/libqtscript_core.so
/usr/lib64/candle/plugins/script/libqtscript_custom.so
/usr/lib64/candle/plugins/script/libqtscript_gui.so
/usr/lib64/candle/plugins/script/libqtscript_multimedia.so
/usr/lib64/candle/plugins/script/libqtscript_network.so
/usr/lib64/candle/plugins/script/libqtscript_opengl.so
/usr/lib64/candle/plugins/script/libqtscript_printsupport.so
/usr/lib64/candle/plugins/script/libqtscript_sql.so
/usr/lib64/candle/plugins/script/libqtscript_uitools.so
/usr/lib64/candle/plugins/script/libqtscript_widgets.so
/usr/lib64/candle/plugins/script/libqtscript_xml.so
/usr/share/applications/candle.desktop
/usr/share/candle
/usr/share/candle/translations
/usr/share/candle/translations/candle_en.qm
/usr/share/candle/translations/candle_es.qm
/usr/share/candle/translations/candle_fr.qm
/usr/share/candle/translations/candle_pt.qm
/usr/share/candle/translations/candle_ru.qm
/usr/share/doc/Candle
/usr/share/doc/Candle/LICENSE
/usr/share/doc/Candle/help
/usr/share/doc/Candle/help/candle.qhc
/usr/share/doc/Candle/help/en
/usr/share/doc/Candle/help/en/appendix
/usr/share/doc/Candle/help/en/candle.qch
/usr/share/doc/Candle/help/en/css
/usr/share/doc/Candle/help/en/img
/usr/share/doc/Candle/help/en/mainwindow
/usr/share/doc/Candle/help/en/mainwindow/panels
/usr/share/doc/Candle/help/en/mainwindow/windows
/usr/share/doc/Candle/help/en/messages
/usr/share/doc/Candle/help/en/plugins
/usr/share/doc/Candle/help/en/process
/usr/share/doc/Candle/help/en/purpose
/usr/share/doc/Candle/help/en/scripting
/usr/share/doc/Candle/help/en/scripting/examples
/usr/share/doc/Candle/help/en/settings
/usr/share/doc/Candle/help/ru
/usr/share/doc/Candle/help/ru/appendix
/usr/share/doc/Candle/help/ru/candle.qch
/usr/share/doc/Candle/help/ru/css
/usr/share/doc/Candle/help/ru/img
/usr/share/doc/Candle/help/ru/mainwindow
/usr/share/doc/Candle/help/ru/mainwindow/panels
/usr/share/doc/Candle/help/ru/mainwindow/windows
/usr/share/doc/Candle/help/ru/messages
/usr/share/doc/Candle/help/ru/plugins
/usr/share/doc/Candle/help/ru/process
/usr/share/doc/Candle/help/ru/purpose
/usr/share/doc/Candle/help/ru/scripting
/usr/share/doc/Candle/help/ru/scripting/examples
/usr/share/doc/Candle/help/ru/settings
/usr/share/doc/Candle/help/script
/usr/share/doc/Candle/help/script/script.qch
/usr/share/doc/candle
/usr/share/doc/candle/readme.md
/usr/share/licenses/candle
/usr/share/licenses/candle/LICENSE
/usr/share/pixmaps/candle.ico
```

Исходники пакета:
https://abf.io/import/candle

Пакет:
[candle-11.2-0.git161506.2-rosa13.x86_64.rpm](https://file-store.rosa.ru/api/v1/file_stores/2e54821783b3869c4da8a9773da61b3ee9a51480) 