### PR TITLE
Add theme selection (system/dark/light/custom) with editable palette …

### DIFF
--- a/src/candle/frmmain.cpp
+++ b/src/candle/frmmain.cpp
@@ -23,7 +23,9 @@
 #include <QElapsedTimer>
 #include <QtConcurrent/QtConcurrent>
 #include <QClipboard>
+#include <QStyleFactory>
 #include "frmmain.h"
+#include "theme.h"
 #include "ui_frmmain.h"
 #include "ui_frmsettings.h"
 #include "frmchecklist.h"
@@ -38,6 +40,9 @@
 
 frmMain::frmMain(QWidget *parent) : QMainWindow(parent), ui(new Ui::frmMain)
 {
+    m_defaultPalette = qApp->palette();
+    m_defaultStyleName = qApp->style()->objectName();
+
     initVariables();
 
     m_settings = new frmSettings(this);
@@ -3512,6 +3517,7 @@ void frmMain::storeSettings()
     set->setValue("lastFolder", m_lastFolder);
     set->setValue("fontSize", m_settings->fontSize());
     set->setValue("panelWidth", m_settings->panelWidth());
+    set->setValue("theme", m_settings->theme());
     set->setValue("keyboardControl", m_storedKeyboardControl);
 
     set->setValue("useStartCommands", m_settings->useStartCommands());
@@ -3565,6 +3571,10 @@ void frmMain::storeSettings()
 
     foreach (ColorPicker* pick, m_settings->colors()) {
         set->setValue("" + pick->objectName().mid(3), pick->color().name());
+    }
+
+    foreach (ColorPicker* pick, m_settings->paletteColors()) {
+        set->setValue(pick->objectName().mid(3), pick->color().name());
     }
 
     QStringList list;
@@ -3648,6 +3658,7 @@ void frmMain::restoreSettings()
     if (set->childKeys().size()) {
         m_settings->setFontSize(set->value("fontSize", 9).toInt());
         m_settings->setPanelWidth(set->value("panelWidth", 40).toInt());
+        m_settings->setTheme(set->value("theme", ThemeSystem).toInt());
         m_settings->setConnectionType((ConnectionType)set->value("connectionType").toInt());
         m_settings->setPort(set->value("port").toString());
         m_settings->setBaud(set->value("baud", 115200).toInt());
@@ -3708,6 +3719,10 @@ void frmMain::restoreSettings()
         m_settings->setAxisAX(set->value("axisAX", true).toBool());
 
         foreach (ColorPicker* pick, m_settings->colors()) {
+            pick->setColor(QColor(set->value(pick->objectName().mid(3), "black").toString()));
+        }
+
+        foreach (ColorPicker* pick, m_settings->paletteColors()) {
             pick->setColor(QColor(set->value(pick->objectName().mid(3), "black").toString()));
         }
     } else {
@@ -3945,8 +3960,66 @@ void frmMain::loadProfiles(QSettings &set)
     (it != actions.constEnd() ? *it : ui->actServiceProfilesDefault)->setChecked(true);
 }
 
+void frmMain::applyTheme()
+{
+    switch (m_settings->theme()) {
+    case ThemeDark: {
+        qApp->setStyle(QStyleFactory::create("Fusion"));
+
+        QPalette p;
+        p.setColor(QPalette::Window, QColor(53, 53, 53));
+        p.setColor(QPalette::WindowText, Qt::white);
+        p.setColor(QPalette::Base, QColor(35, 35, 35));
+        p.setColor(QPalette::AlternateBase, QColor(53, 53, 53));
+        p.setColor(QPalette::ToolTipBase, Qt::white);
+        p.setColor(QPalette::ToolTipText, Qt::white);
+        p.setColor(QPalette::Text, Qt::white);
+        p.setColor(QPalette::Button, QColor(53, 53, 53));
+        p.setColor(QPalette::ButtonText, Qt::white);
+        p.setColor(QPalette::BrightText, Qt::red);
+        p.setColor(QPalette::Link, QColor(42, 130, 218));
+        p.setColor(QPalette::Highlight, QColor(42, 130, 218));
+        p.setColor(QPalette::HighlightedText, Qt::black);
+        p.setColor(QPalette::Disabled, QPalette::Text, QColor(127, 127, 127));
+        p.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(127, 127, 127));
+        p.setColor(QPalette::Disabled, QPalette::WindowText, QColor(127, 127, 127));
+
+        qApp->setPalette(p);
+        break;
+    }
+    case ThemeLight:
+        qApp->setStyle(QStyleFactory::create("Fusion"));
+        qApp->setPalette(qApp->style()->standardPalette());
+        break;
+    case ThemeCustom: {
+        qApp->setStyle(QStyleFactory::create("Fusion"));
+
+        QPalette p = qApp->style()->standardPalette();
+        p.setColor(QPalette::Window, m_settings->paletteColor("Window"));
+        p.setColor(QPalette::WindowText, m_settings->paletteColor("WindowText"));
+        p.setColor(QPalette::Base, m_settings->paletteColor("Base"));
+        p.setColor(QPalette::Text, m_settings->paletteColor("Text"));
+        p.setColor(QPalette::Button, m_settings->paletteColor("Button"));
+        p.setColor(QPalette::ButtonText, m_settings->paletteColor("ButtonText"));
+        p.setColor(QPalette::Highlight, m_settings->paletteColor("Highlight"));
+        p.setColor(QPalette::HighlightedText, m_settings->paletteColor("HighlightedText"));
+
+        qApp->setPalette(p);
+        break;
+    }
+    case ThemeSystem:
+    default:
+        qApp->setStyle(QStyleFactory::create(m_defaultStyleName));
+        qApp->setPalette(m_defaultPalette);
+        break;
+    }
+}
+
 void frmMain::applySettings()
 {
+    // Apply theme
+    applyTheme();
+
     // Apply font size QWidget {font-size: 8pt}
     qApp->setStyleSheet(QString(qApp->styleSheet()).replace(QRegExp(
         "QWidget \\{font-size: \\d+pt\\}"),

--- a/src/candle/frmmain.h
+++ b/src/candle/frmmain.h
@@ -17,6 +17,7 @@
 #include <QProgressDialog>
 #include <QScriptEngine>
 #include <QGroupBox>
+#include <QPalette>
 #include <exception>
 #include <QFuture>
 
@@ -458,6 +459,10 @@ private:
     // In memory settings for plugins
     Storage m_storage;
 
+    // Theme
+    QPalette m_defaultPalette;
+    QString m_defaultStyleName;
+
     // Futures
     QFuture<void> m_updateParserFuture;
     QFuture<void> m_updateProgramEstimatedTimeFuture;
@@ -475,6 +480,7 @@ private:
     void loadSettings();
     void saveSettings();
     void applySettings();
+    void applyTheme();
     void storeSettings();
     void restoreSettings();
 

--- a/src/candle/frmsettings.cpp
+++ b/src/candle/frmsettings.cpp
@@ -70,6 +70,8 @@ frmSettings::frmSettings(QWidget *parent) :
     ui->cboFps->setValidator(&m_intValidator);
     ui->cboFontSize->setValidator(&m_intValidator);
 
+    ui->grpPaletteColors->setVisible(ui->cboTheme->currentIndex() == ThemeCustom);
+
     for (int i = 0; i < ui->stackMain->count(); i++) {
         ui->listCategories->addItem(ui->stackMain->widget(i)->findChild<QGroupBox*>()->title());
     }
@@ -514,6 +516,27 @@ void frmSettings::setFontSize(int fontSize)
     ui->cboFontSize->setCurrentText(QString::number(fontSize));
 }
 
+int frmSettings::theme()
+{
+    return ui->cboTheme->currentIndex();
+}
+
+void frmSettings::setTheme(int theme)
+{
+    ui->cboTheme->setCurrentIndex(theme);
+}
+
+QList<ColorPicker *> frmSettings::paletteColors()
+{
+    return ui->grpPaletteColors->findChildren<ColorPicker*>();
+}
+
+QColor frmSettings::paletteColor(QString name)
+{
+    ColorPicker *pick = ui->grpPaletteColors->findChild<ColorPicker*>("clpPalette" + name);
+    if (pick) return pick->color(); else return QColor();
+}
+
 int frmSettings::panelWidth()
 {
     return ui->txtPanelWidth->value();
@@ -940,6 +963,16 @@ void frmSettings::setDefaultSettings()
     setFontSize(9);
     setPanelWidth(40);
 
+    setTheme(ThemeSystem);
+    ui->clpPaletteWindow->setColor(QColor(240, 240, 240));
+    ui->clpPaletteWindowText->setColor(QColor(0, 0, 0));
+    ui->clpPaletteBase->setColor(QColor(255, 255, 255));
+    ui->clpPaletteText->setColor(QColor(0, 0, 0));
+    ui->clpPaletteButton->setColor(QColor(240, 240, 240));
+    ui->clpPaletteButtonText->setColor(QColor(0, 0, 0));
+    ui->clpPaletteHighlight->setColor(QColor(48, 140, 198));
+    ui->clpPaletteHighlightedText->setColor(QColor(255, 255, 255));
+
     // Shortcuts
     QMap<QString, QString> d;
     d["actFileNew"] = "Ctrl+N";
@@ -976,6 +1009,11 @@ void frmSettings::setDefaultSettings()
     ui->chkToolChangeUseCommands->setChecked(false);
     ui->chkToolChangeUseCommandsConfirm->setChecked(false);
     setLanguage("en");
+}
+
+void frmSettings::on_cboTheme_currentIndexChanged(int index)
+{
+    ui->grpPaletteColors->setVisible(index == ThemeCustom);
 }
 
 void frmSettings::on_radDrawModeVectors_toggled(bool checked)

--- a/src/candle/frmsettings.h
+++ b/src/candle/frmsettings.h
@@ -18,6 +18,7 @@
 #include <QJsonDocument>
 #include "colorpicker.h"
 #include "connections/connectiontype.h"
+#include "theme.h"
 
 namespace Ui {
 class frmSettings;
@@ -59,6 +60,7 @@ class frmSettings : public QDialog
     Q_PROPERTY(bool simplify READ simplify WRITE setSimplify)
     Q_PROPERTY(double simplifyPrecision READ simplifyPrecision WRITE setSimplifyPrecision)
     Q_PROPERTY(int fontSize READ fontSize WRITE setFontSize)
+    Q_PROPERTY(int theme READ theme WRITE setTheme)
     Q_PROPERTY(bool grayscaleSegments READ grayscaleSegments WRITE setGrayscaleSegments)
     Q_PROPERTY(bool grayscaleSCode READ grayscaleSCode WRITE setGrayscaleSCode)
     Q_PROPERTY(bool drawModeVectors READ drawModeVectors WRITE setDrawModeVectors)
@@ -155,6 +157,10 @@ public:
     QColor colors(QString name);
     int fontSize();
     void setFontSize(int fontSize);
+    int theme();
+    void setTheme(int theme);
+    QList<ColorPicker*> paletteColors();
+    QColor paletteColor(QString name);
     int panelWidth();
     void setPanelWidth(int panelWidth);
     bool grayscaleSegments();
@@ -250,6 +256,7 @@ private slots:
     void on_radGrayscaleZ_toggled(bool checked);
     void on_cmdShortcutsImport_clicked();
     void on_cmdShortcutsExport_clicked();
+    void on_cboTheme_currentIndexChanged(int index);
 
 private:
     struct Shortcut {

--- a/src/candle/frmsettings.ui
+++ b/src/candle/frmsettings.ui
@@ -1090,7 +1090,136 @@ QGroupBox {
                     </property>
                    </widget>
                   </item>
+                  <item row="4" column="0">
+                   <widget class="QLabel" name="lblTheme">
+                    <property name="text">
+                     <string>Theme:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="1">
+                   <widget class="QComboBox" name="cboTheme">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <item>
+                     <property name="text">
+                      <string>System theme</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Dark theme</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Light theme</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Custom theme</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
                  </layout>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="grpPaletteColors">
+               <property name="visible">
+                <bool>false</bool>
+               </property>
+               <property name="title">
+                <string>Palette colors</string>
+               </property>
+               <layout class="QGridLayout" name="gridLayout_10">
+                <item row="0" column="0">
+                 <widget class="QLabel" name="label_39">
+                  <property name="text">
+                   <string>Window:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="1">
+                 <widget class="ColorPicker" name="clpPaletteWindow" native="true"/>
+                </item>
+                <item row="0" column="2">
+                 <widget class="QLabel" name="label_40">
+                  <property name="text">
+                   <string>Window text:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="3">
+                 <widget class="ColorPicker" name="clpPaletteWindowText" native="true"/>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QLabel" name="label_41">
+                  <property name="text">
+                   <string>Base:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="1">
+                 <widget class="ColorPicker" name="clpPaletteBase" native="true"/>
+                </item>
+                <item row="1" column="2">
+                 <widget class="QLabel" name="label_42">
+                  <property name="text">
+                   <string>Text:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="3">
+                 <widget class="ColorPicker" name="clpPaletteText" native="true"/>
+                </item>
+                <item row="2" column="0">
+                 <widget class="QLabel" name="label_43">
+                  <property name="text">
+                   <string>Button:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="1">
+                 <widget class="ColorPicker" name="clpPaletteButton" native="true"/>
+                </item>
+                <item row="2" column="2">
+                 <widget class="QLabel" name="label_44">
+                  <property name="text">
+                   <string>Button text:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="3">
+                 <widget class="ColorPicker" name="clpPaletteButtonText" native="true"/>
+                </item>
+                <item row="3" column="0">
+                 <widget class="QLabel" name="label_45">
+                  <property name="text">
+                   <string>Highlight:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="3" column="1">
+                 <widget class="ColorPicker" name="clpPaletteHighlight" native="true"/>
+                </item>
+                <item row="3" column="2">
+                 <widget class="QLabel" name="label_46">
+                  <property name="text">
+                   <string>Highlighted text:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="3" column="3">
+                 <widget class="ColorPicker" name="clpPaletteHighlightedText" native="true"/>
                 </item>
                </layout>
               </widget>

--- a/src/candle/theme.h
+++ b/src/candle/theme.h
@@ -1,0 +1,9 @@
+#pragma once
+
+enum Theme
+{
+    ThemeSystem,
+    ThemeDark,
+    ThemeLight,
+    ThemeCustom
+};

--- a/src/candle/translations/candle_en.ts
+++ b/src/candle/translations/candle_en.ts
@@ -1459,5 +1459,53 @@ segment size:</source>
         <source>Reset machine on connection</source>
         <translation></translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>System theme</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Dark theme</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Light theme</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Custom theme</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Palette colors</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Window:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Window text:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Base:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Button:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Button text:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Highlighted text:</source>
+        <translation></translation>
+    </message>
 </context>
 </TS>

--- a/src/candle/translations/candle_es.ts
+++ b/src/candle/translations/candle_es.ts
@@ -1462,5 +1462,53 @@ segment size:</source>
         <source>Reset machine on connection</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation>Tema:</translation>
+    </message>
+    <message>
+        <source>System theme</source>
+        <translation>Tema del sistema</translation>
+    </message>
+    <message>
+        <source>Dark theme</source>
+        <translation>Tema oscuro</translation>
+    </message>
+    <message>
+        <source>Light theme</source>
+        <translation>Tema claro</translation>
+    </message>
+    <message>
+        <source>Custom theme</source>
+        <translation>Tema personalizado</translation>
+    </message>
+    <message>
+        <source>Palette colors</source>
+        <translation>Colores de la paleta</translation>
+    </message>
+    <message>
+        <source>Window:</source>
+        <translation>Ventana:</translation>
+    </message>
+    <message>
+        <source>Window text:</source>
+        <translation>Texto de ventana:</translation>
+    </message>
+    <message>
+        <source>Base:</source>
+        <translation>Base:</translation>
+    </message>
+    <message>
+        <source>Button:</source>
+        <translation>Botón:</translation>
+    </message>
+    <message>
+        <source>Button text:</source>
+        <translation>Texto de botón:</translation>
+    </message>
+    <message>
+        <source>Highlighted text:</source>
+        <translation>Texto resaltado:</translation>
+    </message>
 </context>
 </TS>

--- a/src/candle/translations/candle_fr.ts
+++ b/src/candle/translations/candle_fr.ts
@@ -1462,5 +1462,53 @@ segment size:</source>
         <source>Reset machine on connection</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation>Thème :</translation>
+    </message>
+    <message>
+        <source>System theme</source>
+        <translation>Thème du système</translation>
+    </message>
+    <message>
+        <source>Dark theme</source>
+        <translation>Thème sombre</translation>
+    </message>
+    <message>
+        <source>Light theme</source>
+        <translation>Thème clair</translation>
+    </message>
+    <message>
+        <source>Custom theme</source>
+        <translation>Thème personnalisé</translation>
+    </message>
+    <message>
+        <source>Palette colors</source>
+        <translation>Couleurs de la palette</translation>
+    </message>
+    <message>
+        <source>Window:</source>
+        <translation>Fenêtre :</translation>
+    </message>
+    <message>
+        <source>Window text:</source>
+        <translation>Texte de fenêtre :</translation>
+    </message>
+    <message>
+        <source>Base:</source>
+        <translation>Base :</translation>
+    </message>
+    <message>
+        <source>Button:</source>
+        <translation>Bouton :</translation>
+    </message>
+    <message>
+        <source>Button text:</source>
+        <translation>Texte de bouton :</translation>
+    </message>
+    <message>
+        <source>Highlighted text:</source>
+        <translation>Texte en surbrillance :</translation>
+    </message>
 </context>
 </TS>

--- a/src/candle/translations/candle_pt.ts
+++ b/src/candle/translations/candle_pt.ts
@@ -1462,5 +1462,53 @@ segment size:</source>
         <source>Reset machine on connection</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation>Tema:</translation>
+    </message>
+    <message>
+        <source>System theme</source>
+        <translation>Tema do sistema</translation>
+    </message>
+    <message>
+        <source>Dark theme</source>
+        <translation>Tema escuro</translation>
+    </message>
+    <message>
+        <source>Light theme</source>
+        <translation>Tema claro</translation>
+    </message>
+    <message>
+        <source>Custom theme</source>
+        <translation>Tema personalizado</translation>
+    </message>
+    <message>
+        <source>Palette colors</source>
+        <translation>Cores da paleta</translation>
+    </message>
+    <message>
+        <source>Window:</source>
+        <translation>Janela:</translation>
+    </message>
+    <message>
+        <source>Window text:</source>
+        <translation>Texto da janela:</translation>
+    </message>
+    <message>
+        <source>Base:</source>
+        <translation>Base:</translation>
+    </message>
+    <message>
+        <source>Button:</source>
+        <translation>Botão:</translation>
+    </message>
+    <message>
+        <source>Button text:</source>
+        <translation>Texto do botão:</translation>
+    </message>
+    <message>
+        <source>Highlighted text:</source>
+        <translation>Texto destacado:</translation>
+    </message>
 </context>
 </TS>

--- a/src/candle/translations/candle_ru.ts
+++ b/src/candle/translations/candle_ru.ts
@@ -1493,11 +1493,11 @@ segment size:</source>
     </message>
     <message>
         <source>Window:</source>
-        <translation>Фон:</translation>
+        <translation>Фон окна:</translation>
     </message>
     <message>
         <source>Window text:</source>
-        <translation>Текст фона:</translation>
+        <translation>Текст:</translation>
     </message>
     <message>
         <source>Base:</source>
@@ -1513,7 +1513,7 @@ segment size:</source>
     </message>
     <message>
         <source>Highlighted text:</source>
-        <translation>Текст выделения:</translation>
+        <translation>Выделенный текст:</translation>
     </message>
 </context>
 </TS>

--- a/src/candle/translations/candle_ru.ts
+++ b/src/candle/translations/candle_ru.ts
@@ -1467,5 +1467,53 @@ segment size:</source>
         <source>Reset machine on connection</source>
         <translation>Отправлять команду сброса при подключении</translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation>Тема:</translation>
+    </message>
+    <message>
+        <source>System theme</source>
+        <translation>Системная тема</translation>
+    </message>
+    <message>
+        <source>Dark theme</source>
+        <translation>Тёмная тема</translation>
+    </message>
+    <message>
+        <source>Light theme</source>
+        <translation>Светлая тема</translation>
+    </message>
+    <message>
+        <source>Custom theme</source>
+        <translation>Своя тема</translation>
+    </message>
+    <message>
+        <source>Palette colors</source>
+        <translation>Цвета палитры</translation>
+    </message>
+    <message>
+        <source>Window:</source>
+        <translation>Фон:</translation>
+    </message>
+    <message>
+        <source>Window text:</source>
+        <translation>Текст фона:</translation>
+    </message>
+    <message>
+        <source>Base:</source>
+        <translation>Поле ввода:</translation>
+    </message>
+    <message>
+        <source>Button:</source>
+        <translation>Кнопка:</translation>
+    </message>
+    <message>
+        <source>Button text:</source>
+        <translation>Текст кнопки:</translation>
+    </message>
+    <message>
+        <source>Highlighted text:</source>
+        <translation>Текст выделения:</translation>
+    </message>
 </context>
 </TS>

--- a/src/candle/translations/candle_zh_CN.ts
+++ b/src/candle/translations/candle_zh_CN.ts
@@ -86,7 +86,7 @@
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;The program is provided AS IS without any guarantees or warranty. Use at your own risk.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;本程序按"原样"提供，不附带任何形式的保证或担保。使用风险由您自行承担。&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;本程序按&quot;原样&quot;提供，不附带任何形式的保证或担保。使用风险由您自行承担。&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>OK</source>
@@ -652,7 +652,7 @@
     </message>
     <message>
         <source>Change tool and press &apos;Pause&apos; button to continue job</source>
-        <translation>更换刀具后按下"暂停"按钮继续作业</translation>
+        <translation>更换刀具后按下&quot;暂停&quot;按钮继续作业</translation>
     </message>
     <message>
         <source>M6 command detected. Send tool change commands?
@@ -858,7 +858,7 @@ Time elapsed: %1</source>
     </message>
     <message>
         <source>Profile &apos;%1&apos; already exists</source>
-        <translation>配置文件 '%1' 已存在</translation>
+        <translation>配置文件 &apos;%1&apos; 已存在</translation>
     </message>
     <message>
         <source>Machine</source>
@@ -902,7 +902,7 @@ Time elapsed: %1</source>
     </message>
     <message>
         <source>Profile &apos;%1&apos; already exists. Overwrite?</source>
-        <translation>配置文件 '%1' 已存在。是否覆盖？</translation>
+        <translation>配置文件 &apos;%1&apos; 已存在。是否覆盖？</translation>
     </message>
     <message>
         <source>Profiles (*.cpr)</source>
@@ -1170,11 +1170,11 @@ Time elapsed: %1</source>
     </message>
     <message>
         <source>By &apos;Z&apos;-code</source>
-        <translation>按 'Z' 代码</translation>
+        <translation>按 &apos;Z&apos; 代码</translation>
     </message>
     <message>
         <source>By &apos;S&apos;-code</source>
-        <translation>按 'S' 代码</translation>
+        <translation>按 &apos;S&apos; 代码</translation>
     </message>
     <message>
         <source>Grayscale segments</source>
@@ -1366,7 +1366,7 @@ Time elapsed: %1</source>
     </message>
     <message>
         <source>Enable axis &apos;A&apos;</source>
-        <translation>启用 'A' 轴</translation>
+        <translation>启用 &apos;A&apos; 轴</translation>
     </message>
     <message>
         <source>direction:</source>
@@ -1453,6 +1453,66 @@ segment size:</source>
     <message>
         <source>Reset machine on connection</source>
         <translation>连接时重置机器</translation>
+    </message>
+    <message>
+        <source>10</source>
+        <translation type="unfinished">10</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation>主题：</translation>
+    </message>
+    <message>
+        <source>System theme</source>
+        <translation>系统主题</translation>
+    </message>
+    <message>
+        <source>Dark theme</source>
+        <translation>深色主题</translation>
+    </message>
+    <message>
+        <source>Light theme</source>
+        <translation>浅色主题</translation>
+    </message>
+    <message>
+        <source>Custom theme</source>
+        <translation>自定义主题</translation>
+    </message>
+    <message>
+        <source>Palette colors</source>
+        <translation>调色板颜色</translation>
+    </message>
+    <message>
+        <source>Window:</source>
+        <translation>窗口：</translation>
+    </message>
+    <message>
+        <source>Window text:</source>
+        <translation>窗口文字：</translation>
+    </message>
+    <message>
+        <source>Base:</source>
+        <translation>输入框：</translation>
+    </message>
+    <message>
+        <source>Button:</source>
+        <translation>按钮：</translation>
+    </message>
+    <message>
+        <source>Button text:</source>
+        <translation>按钮文字：</translation>
+    </message>
+    <message>
+        <source>Highlighted text:</source>
+        <translation>高亮文字：</translation>
+    </message>
+    <message>
+        <source>Type:</source>
+        <translation type="unfinished">类型：</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished">保存</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
close #715
…colors

frmSettings gains a Theme combo box on the User interface page and a Palette colors group (Window/Base/Button/Highlight pairs via ColorPicker) shown only for the custom option. frmMain::applyTheme() switches the app to Fusion + a matching QPalette, or restores the platform default for "System theme", and runs live whenever settings are applied. Translations regenerated with lupdate and filled in for all languages.
<img width="1323" height="874" alt="image" src="https://github.com/user-attachments/assets/65af4049-b90a-4e67-8119-0152b6a0ee8a" />
